### PR TITLE
Call init before tests in basic_boot

### DIFF
--- a/tests/basic_boot.rs
+++ b/tests/basic_boot.rs
@@ -8,6 +8,7 @@ use core::panic::PanicInfo;
 
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
+    yonti_os::init();
     test_main();
 
     loop {}


### PR DESCRIPTION
## Summary
- initialize the kernel early in `tests/basic_boot.rs`

## Testing
- `cargo test --no-run` *(fails: Error loading target specification)*

------
https://chatgpt.com/codex/tasks/task_b_683c3c7fc36c833387d5d7eae1ec2959