### PR TITLE
Fix allocator init

### DIFF
--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -36,7 +36,7 @@ unsafe impl GlobalAlloc for Dummy {
     }
 
     unsafe fn dealloc(&self, _ptr: *mut u8, _layout: Layout) {
-        panic!("dealloc should be never called")
+        panic!("dealloc should never be called")
     }
 }
 
@@ -65,9 +65,10 @@ pub fn init_heap(
             .ok_or(MapToError::FrameAllocationFailed)?;
         let flags = PageTableFlags::PRESENT | PageTableFlags::WRITABLE;
         unsafe { mapper.map_to(page, frame, flags, frame_allocator)?.flush() };
-        unsafe {
-            ALLOCATOR.lock().init(HEAP_START, HEAP_SIZE);
-        }
+    }
+
+    unsafe {
+        ALLOCATOR.lock().init(HEAP_START, HEAP_SIZE);
     }
 
     Ok(())


### PR DESCRIPTION
## Summary
- fix grammar in panic message
- initialize heap only once

## Testing
- `cargo test` *(fails: Error loading target specification)*

------
https://chatgpt.com/codex/tasks/task_b_683c3b6b133c8333b52d794a3161f913