### PR TITLE
Fix custom target layout

### DIFF
--- a/x86_64-yonti_os.json
+++ b/x86_64-yonti_os.json
@@ -1,6 +1,6 @@
  {
    "llvm-target": "x86_64-unknown-none",
-    "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
+   "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
     "arch": "x86_64",
     "target-endian": "little",
     "target-pointer-width": "64",
@@ -11,6 +11,6 @@
     "linker": "rust-lld" ,
     "panic-strategy": "abort",
     "disable-redzone": true,
-    "features": "-mmx,-sse,+soft-float"
+   "features": "-mmx,-sse"
 
  }


### PR DESCRIPTION
## Summary
- update the `data-layout` in `x86_64-yonti_os.json` to match the default layout of `x86_64-unknown-none`
- remove the obsolete `+soft-float` feature flag

## Testing
- `cargo check` *(fails: Could not connect to server)*

------
https://chatgpt.com/codex/tasks/task_b_683c63441ffc8333b84e947b56dba403