### PR TITLE
Fix SSE compilation failure

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,12 +14,14 @@ pub mod memory;
 pub mod serial;
 pub mod task;
 pub mod vga_buffer;
+pub mod sse;
 
 use core::panic::PanicInfo;
 
 pub fn init() {
     use x86_64::instructions;
     gdt::init();
+    unsafe { sse::init(); }
     interrupts::init_idt();
     unsafe { interrupts::PICS.lock().initialize() };
     instructions::interrupts::enable();

--- a/src/sse.rs
+++ b/src/sse.rs
@@ -1,0 +1,23 @@
+use core::arch::asm;
+
+/// Enable SSE instructions by configuring control registers.
+///
+/// # Safety
+/// This function performs privileged register modifications and must
+/// only be called during early kernel initialization before any
+/// floating point operations are executed.
+pub unsafe fn init() {
+    let mut cr0: u64;
+    asm!("mov {}, cr0", out(reg) cr0, options(nostack, preserves_flags));
+    // clear EM (bit 2) and TS (bit 3)
+    cr0 &= !((1 << 2) | (1 << 3));
+    // set MP (bit 1) and NE (bit 5)
+    cr0 |= (1 << 1) | (1 << 5);
+    asm!("mov cr0, {}", in(reg) cr0, options(nostack, preserves_flags));
+
+    let mut cr4: u64;
+    asm!("mov {}, cr4", out(reg) cr4, options(nostack, preserves_flags));
+    // set OSFXSR (bit 9) and OSXMMEXCPT (bit 10)
+    cr4 |= (1 << 9) | (1 << 10);
+    asm!("mov cr4, {}", in(reg) cr4, options(nostack, preserves_flags));
+}

--- a/x86_64-yonti_os.json
+++ b/x86_64-yonti_os.json
@@ -11,6 +11,6 @@
     "linker": "rust-lld" ,
     "panic-strategy": "abort",
     "disable-redzone": true,
-   "features": "-mmx,-sse"
+    "features": "-mmx,+sse,+sse2"
 
  }


### PR DESCRIPTION
## Summary
- enable SSE and SSE2 support in custom target
- add sse module to initialize control registers
- initialize SSE during kernel setup

## Testing
- `cargo check` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_b_683c641d9b5c833394561c4483ccbd80