### PR TITLE
Update x86_64 crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ harness = false
 volatile = "0.2.6"
 bootloader = { version = "0.9.23", features = ["map_physical_memory"]}
 spin = "0.5.2"
-x86_64 = "0.14.2"
+x86_64 = "0.15.0"
 uart_16550 = "0.2.0"
 pic8259 = "0.10.1"
 pc-keyboard = "0.5.0"

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -3,7 +3,7 @@ pub mod fixed_size_block;
 pub mod linked_list;
 
 use alloc::alloc::{GlobalAlloc, Layout};
-use core::ptr::null_mut;
+use core::{convert::TryFrom, ptr::null_mut};
 use fixed_size_block::FixedSizeBlockAllocator;
 
 pub const HEAP_START: usize = 0x_4444_4444_0000;
@@ -53,7 +53,7 @@ pub fn init_heap(
 ) -> Result<(), MapToError<Size4KiB>> {
     let page_range = {
         let heap_start = VirtAddr::new(HEAP_START as u64);
-        let heap_end = heap_start + HEAP_SIZE - 1u64;
+        let heap_end = heap_start + u64::try_from(HEAP_SIZE).unwrap() - 1u64;
         let heap_start_page = Page::containing_address(heap_start);
         let heap_end_page = Page::containing_address(heap_end);
         Page::range_inclusive(heap_start_page, heap_end_page)

--- a/src/gdt.rs
+++ b/src/gdt.rs
@@ -1,4 +1,4 @@
-use core::ptr::addr_of;
+use core::{convert::TryFrom, ptr::addr_of};
 use lazy_static::lazy_static;
 use x86_64::structures::{
     gdt::{Descriptor, GlobalDescriptorTable, SegmentSelector},
@@ -16,7 +16,7 @@ lazy_static! {
             static mut STACK: [u8; STACK_SIZE] = [0; STACK_SIZE];
 
             let stack_start = VirtAddr::from_ptr(unsafe { addr_of!(STACK) });
-            stack_start + STACK_SIZE
+            stack_start + u64::try_from(STACK_SIZE).unwrap()
         };
         tss
     };
@@ -30,8 +30,8 @@ struct Selectors {
 lazy_static! {
     static ref GDT: (GlobalDescriptorTable, Selectors) = {
         let mut gdt = GlobalDescriptorTable::new();
-        let code_selector = gdt.add_entry(Descriptor::kernel_code_segment());
-        let tss_selector = gdt.add_entry(Descriptor::tss_segment(&TSS));
+        let code_selector = gdt.push(Descriptor::kernel_code_segment());
+        let tss_selector = gdt.push(Descriptor::tss_segment(&TSS));
         (
             gdt,
             Selectors {

--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -42,8 +42,8 @@ lazy_static! {
                 .set_handler_fn(double_fault_handler)
                 .set_stack_index(gdt::DOUBLE_FAULT_IST_INDEX);
         }
-        idt[InterruptIndex::Timer.as_usize()].set_handler_fn(timer_interrupt_handler);
-        idt[InterruptIndex::Keyboard.as_usize()].set_handler_fn(keyboard_interrupt_handler);
+        idt.interrupts[InterruptIndex::Timer.as_usize()].set_handler_fn(timer_interrupt_handler);
+        idt.interrupts[InterruptIndex::Keyboard.as_usize()].set_handler_fn(keyboard_interrupt_handler);
         idt
     };
 }


### PR DESCRIPTION
## Summary
- revert manual Cargo.lock edit
- update heap and GDT code for new `x86_64`
- adjust IDT handler registration

## Testing
- `cargo update -p x86_64` *(fails: Could not connect to server)*
- `cargo check` *(fails: Could not connect to server)*

------
https://chatgpt.com/codex/tasks/task_b_683c674fb2248333b52d0cab89d859d1