### PR TITLE
Update x86_64 crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ checksum = "442887c63f2c839b346c192d047a7c87e73d0689c9157b00b53dcc27dd5ea793"
 
 [[package]]
 name = "x86_64"
-version = "0.14.11"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b835097a84e4457323331ec5d6eb23d096066cbfb215d54096dcb4b2e85f500"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ harness = false
 volatile = "0.2.6"
 bootloader = { version = "0.9.23", features = ["map_physical_memory"]}
 spin = "0.5.2"
-x86_64 = "0.14.2"
+x86_64 = "0.15.2"
 uart_16550 = "0.2.0"
 pic8259 = "0.10.1"
 pc-keyboard = "0.5.0"


### PR DESCRIPTION
## Summary
- update the `x86_64` dependency to `0.15.2` in both `Cargo.toml` and `Cargo.lock`

## Testing
- `cargo check` *(fails: Could not connect to server)*

------
https://chatgpt.com/codex/tasks/task_b_683c674fb2248333b52d0cab89d859d1