### PR TITLE
refactor: upgrade to rust 2024 edition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,9 +61,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "pc-keyboard"
-version = "0.5.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6f2d937e3b8d63449b01401e2bae4041bc9dd1129c2e3e0d239407cf6635ac"
+checksum = "73c53b65bbadd653c9d125e745d2659a3a060539b17d96ab1c59f9f5bfdacce5"
 
 [[package]]
 name = "rustversion"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [workspace.package]
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [profile.dev]
 panic = "abort"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,7 +10,7 @@ bazel_dep(name = "platforms", version = "1.0.0")
 
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.toolchain(
-    edition = "2021",
+    edition = "2024",
     versions = ["nightly/2026-05-21"],
     extra_target_triples = [
         "x86_64-unknown-none",

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "yonti_os"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 
 [[test]]
@@ -15,16 +15,16 @@ harness = false
 [dependencies]
 bootloader_api = "0.11.15"
 spin = { version = "0.9.8", default-features = false, features = ["spin_mutex", "once", "lock_api"] }
-x86_64 = "0.15.2"
-pc-keyboard = "0.5.0"
-linked_list_allocator = "0.10.2"
+x86_64 = "0.15.4"
+pc-keyboard = "0.9.0"
+linked_list_allocator = "0.10.6"
 
 [dependencies.lazy_static]
-version = "1.0"
+version = "1.5.0"
 features = ["spin_no_std"]
 
 [dependencies.log]
-version = "0.4"
+version = "0.4.29"
 default-features = false
 features = ["release_max_level_info"]
 

--- a/kernel/src/allocator.rs
+++ b/kernel/src/allocator.rs
@@ -43,7 +43,9 @@ unsafe impl GlobalAlloc for Locked<TlsfAllocator> {
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        self.lock().free(ptr);
+        unsafe {
+            self.lock().free(ptr);
+        }
         monitor::inc_free(layout.size());
         crate::trace_event!(TraceEventId::Free, layout.size(), ptr as u64);
     }
@@ -62,10 +64,10 @@ unsafe impl GlobalAlloc for Dummy {
 }
 
 use x86_64::{
-    structures::paging::{
-        mapper::MapToError, FrameAllocator, Mapper, Page, PageTableFlags, Size4KiB,
-    },
     VirtAddr,
+    structures::paging::{
+        FrameAllocator, Mapper, Page, PageTableFlags, Size4KiB, mapper::MapToError,
+    },
 };
 
 pub fn init_heap(

--- a/kernel/src/allocator/bump.rs
+++ b/kernel/src/allocator/bump.rs
@@ -1,4 +1,4 @@
-use super::{align_up, Locked};
+use super::{Locked, align_up};
 use alloc::alloc::{GlobalAlloc, Layout};
 use core::ptr;
 

--- a/kernel/src/allocator/fixed_size_block.rs
+++ b/kernel/src/allocator/fixed_size_block.rs
@@ -36,8 +36,10 @@ impl FixedSizeBlockAllocator {
     /// The caller must guarantee that the given heap bounds are valid,
     /// the heap is unused, and this method is called only once.
     pub unsafe fn init(&mut self, heap_start: usize, heap_size: usize) {
-        self.fallback_allocator
-            .init(heap_start as *mut u8, heap_size);
+        unsafe {
+            self.fallback_allocator
+                .init(heap_start as *mut u8, heap_size);
+        }
     }
 
     /// Allocates using the fallback allocator.
@@ -91,12 +93,16 @@ unsafe impl GlobalAlloc for Locked<FixedSizeBlockAllocator> {
                 assert!(mem::size_of::<ListNode>() <= BLOCK_SIZES[index]);
                 assert!(mem::align_of::<ListNode>() <= BLOCK_SIZES[index]);
                 let new_node_ptr = ptr as *mut ListNode;
-                new_node_ptr.write(new_node);
-                allocator.list_heads[index] = Some(&mut *new_node_ptr);
+                unsafe {
+                    new_node_ptr.write(new_node);
+                    allocator.list_heads[index] = Some(&mut *new_node_ptr);
+                }
             }
             None => {
                 let ptr = NonNull::new(ptr).unwrap();
-                allocator.fallback_allocator.deallocate(ptr, layout);
+                unsafe {
+                    allocator.fallback_allocator.deallocate(ptr, layout);
+                }
             }
         }
     }

--- a/kernel/src/allocator/linked_list.rs
+++ b/kernel/src/allocator/linked_list.rs
@@ -1,4 +1,4 @@
-use super::{align_up, Locked};
+use super::{Locked, align_up};
 use alloc::alloc::{GlobalAlloc, Layout};
 use core::mem;
 use core::ptr;
@@ -41,7 +41,9 @@ impl LinkedListAllocator {
     /// The caller must guarantee that the given heap bounds are valid,
     /// the heap is unused, and this method is called only once.
     pub unsafe fn init(&mut self, heap_start: usize, heap_size: usize) {
-        self.add_free_region(heap_start, heap_size);
+        unsafe {
+            self.add_free_region(heap_start, heap_size);
+        }
     }
 
     /// Adds the given memory region to the front of the list.
@@ -54,8 +56,10 @@ impl LinkedListAllocator {
         let mut node = ListNode::new(size);
         node.next = self.head.next.take();
         let node_ptr = addr as *mut ListNode;
-        node_ptr.write(node);
-        self.head.next = Some(&mut *node_ptr)
+        unsafe {
+            node_ptr.write(node);
+            self.head.next = Some(&mut *node_ptr)
+        }
     }
 
     /// Looks for a free region with the given size and alignment and removes
@@ -131,7 +135,9 @@ unsafe impl GlobalAlloc for Locked<LinkedListAllocator> {
             let alloc_end = alloc_start.checked_add(size).expect("overflow");
             let excess_size = region.end_addr() - alloc_end;
             if excess_size > 0 {
-                allocator.add_free_region(alloc_end, excess_size);
+                unsafe {
+                    allocator.add_free_region(alloc_end, excess_size);
+                }
             }
             alloc_start as *mut u8
         } else {
@@ -143,6 +149,6 @@ unsafe impl GlobalAlloc for Locked<LinkedListAllocator> {
         // perform layout adjustments
         let (size, _) = LinkedListAllocator::size_align(layout);
 
-        self.lock().add_free_region(ptr as usize, size)
+        unsafe { self.lock().add_free_region(ptr as usize, size) }
     }
 }

--- a/kernel/src/allocator/tlsf.rs
+++ b/kernel/src/allocator/tlsf.rs
@@ -84,19 +84,21 @@ impl TlsfAllocator {
     /// # Safety
     /// Must be called exactly once with a valid, unused memory region.
     pub unsafe fn init(&mut self, heap_start: usize, heap_size: usize) {
-        self.heap_start = heap_start;
-        self.heap_end = heap_start + heap_size;
+        unsafe {
+            self.heap_start = heap_start;
+            self.heap_end = heap_start + heap_size;
 
-        let block = heap_start as *mut BlockHeader;
-        (*block).prev_phys_size = 0;
-        (*block).set(heap_size, true, false);
+            let block = heap_start as *mut BlockHeader;
+            (*block).prev_phys_size = 0;
+            (*block).set(heap_size, true, false);
 
-        let sentinel = (heap_start + heap_size) as *mut BlockHeader;
-        (*sentinel).prev_phys_size = heap_size as u32;
-        (*sentinel).set(0, false, true);
+            let sentinel = (heap_start + heap_size) as *mut BlockHeader;
+            (*sentinel).prev_phys_size = heap_size as u32;
+            (*sentinel).set(0, false, true);
 
-        let node = NonNull::new_unchecked(block);
-        self.insert(node, heap_size);
+            let node = NonNull::new_unchecked(block);
+            self.insert(node, heap_size);
+        }
     }
 
     /// Allocate a block of at least `size` bytes with the given alignment.
@@ -126,40 +128,42 @@ impl TlsfAllocator {
     /// `ptr` must have been returned by a prior `malloc()` call and not
     /// already freed. Passing a null pointer is safe (no-op).
     pub unsafe fn free(&mut self, ptr: *mut u8) {
-        if ptr.is_null() {
-            return;
+        unsafe {
+            if ptr.is_null() {
+                return;
+            }
+            let mut header = (ptr as usize - HEADER_SIZE) as *mut BlockHeader;
+            let mut size = (*header).size();
+            let mut addr = header as usize;
+
+            (*header).mark_free(true);
+
+            // forward coalesce
+            let next_ptr = (addr + size) as *mut BlockHeader;
+            if (next_ptr as usize) < self.heap_end && (*next_ptr).is_free() {
+                self.remove(NonNull::new_unchecked(next_ptr));
+                size += (*next_ptr).size();
+                (*header).set(size, true, (*header).prev_is_free());
+            }
+
+            // backward coalesce
+            if (*header).prev_is_free() {
+                let prev_size = (*header).prev_phys_size as usize;
+                let prev = (addr - prev_size) as *mut BlockHeader;
+                self.remove(NonNull::new_unchecked(prev));
+                size += prev_size;
+                header = prev;
+                addr = prev as usize;
+                (*prev).set(size, true, (*prev).prev_is_free());
+            }
+
+            // update next block
+            let next = (addr + size) as *mut BlockHeader;
+            (*next).prev_phys_size = size as u32;
+            (*next).mark_prev_free(true);
+
+            self.insert(NonNull::new_unchecked(header), size);
         }
-        let mut header = (ptr as usize - HEADER_SIZE) as *mut BlockHeader;
-        let mut size = (*header).size();
-        let mut addr = header as usize;
-
-        (*header).mark_free(true);
-
-        // forward coalesce
-        let next_ptr = (addr + size) as *mut BlockHeader;
-        if (next_ptr as usize) < self.heap_end && (*next_ptr).is_free() {
-            self.remove(NonNull::new_unchecked(next_ptr));
-            size += (*next_ptr).size();
-            (*header).set(size, true, (*header).prev_is_free());
-        }
-
-        // backward coalesce
-        if (*header).prev_is_free() {
-            let prev_size = (*header).prev_phys_size as usize;
-            let prev = (addr - prev_size) as *mut BlockHeader;
-            self.remove(NonNull::new_unchecked(prev));
-            size += prev_size;
-            header = prev;
-            addr = prev as usize;
-            (*prev).set(size, true, (*prev).prev_is_free());
-        }
-
-        // update next block
-        let next = (addr + size) as *mut BlockHeader;
-        (*next).prev_phys_size = size as u32;
-        (*next).mark_prev_free(true);
-
-        self.insert(NonNull::new_unchecked(header), size);
     }
 
     // ── internal helpers ────────────────────────────────────────

--- a/kernel/src/fs/inode.rs
+++ b/kernel/src/fs/inode.rs
@@ -46,7 +46,7 @@ impl Inode {
     /// Returns an error if this inode is a directory.
     pub fn write(&mut self, data: &[u8]) -> Result<(), &'static str> {
         match &mut self.kind {
-            InodeKind::File(ref mut buf) => {
+            InodeKind::File(buf) => {
                 *buf = Vec::from(data);
                 Ok(())
             }
@@ -56,7 +56,7 @@ impl Inode {
 
     pub fn append(&mut self, data: &[u8]) -> Result<(), &'static str> {
         match &mut self.kind {
-            InodeKind::File(ref mut buf) => {
+            InodeKind::File(buf) => {
                 buf.extend_from_slice(data);
                 Ok(())
             }

--- a/kernel/src/gdt.rs
+++ b/kernel/src/gdt.rs
@@ -1,10 +1,10 @@
 use core::{convert::TryFrom, ptr::addr_of};
 use lazy_static::lazy_static;
+use x86_64::VirtAddr;
 use x86_64::structures::{
     gdt::{Descriptor, GlobalDescriptorTable, SegmentSelector},
     tss::TaskStateSegment,
 };
-use x86_64::VirtAddr;
 
 pub const DOUBLE_FAULT_IST_INDEX: u16 = 0;
 
@@ -43,7 +43,7 @@ lazy_static! {
 }
 
 pub fn init() {
-    use x86_64::instructions::segmentation::{Segment, CS};
+    use x86_64::instructions::segmentation::{CS, Segment};
     use x86_64::instructions::tables::load_tss;
 
     GDT.0.load();

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -100,7 +100,7 @@ pub fn test_panic_handler(info: &PanicInfo) -> ! {
 }
 
 #[cfg(all(test, not(bazel)))]
-use bootloader_api::{entry_point, BootInfo};
+use bootloader_api::{BootInfo, entry_point};
 
 #[cfg(all(test, not(bazel)))]
 entry_point!(test_kernel_main, config = &BOOTLOADER_CONFIG);

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -6,7 +6,7 @@
 
 extern crate alloc;
 
-use bootloader_api::{entry_point, BootInfo};
+use bootloader_api::{BootInfo, entry_point};
 use core::panic::PanicInfo;
 use x86_64::VirtAddr;
 use yonti_os::allocator;
@@ -15,7 +15,7 @@ use yonti_os::log;
 use yonti_os::memory;
 use yonti_os::println;
 use yonti_os::task::keyboard;
-use yonti_os::task::{executor::Executor, Task};
+use yonti_os::task::{Task, executor::Executor};
 use yonti_os::trace;
 
 entry_point!(kernel_main, config = &yonti_os::BOOTLOADER_CONFIG);
@@ -72,10 +72,10 @@ fn demo_fs() {
     fs.create_file("/hello.txt").expect("create /hello.txt");
     fs.write_file("/hello.txt", b"Hello from Yonti-os filesystem!")
         .expect("write /hello.txt");
-    if let Ok(data) = fs.read_file("/hello.txt") {
-        if let Ok(s) = core::str::from_utf8(&data) {
-            println!("[fs] /hello.txt: {}", s);
-        }
+    if let Ok(data) = fs.read_file("/hello.txt")
+        && let Ok(s) = core::str::from_utf8(&data)
+    {
+        println!("[fs] /hello.txt: {}", s);
     }
     fs.create_dir("/home").expect("create /home");
     fs.create_file("/home/test").expect("create /home/test");

--- a/kernel/src/memory.rs
+++ b/kernel/src/memory.rs
@@ -2,11 +2,11 @@ pub mod buddy;
 
 use x86_64::registers::control::Cr3;
 use x86_64::{
+    PhysAddr, VirtAddr,
     structures::paging::{
         FrameAllocator, Mapper, OffsetPageTable, Page, PageTable, PageTableFlags as Flags,
         PhysFrame, Size4KiB,
     },
-    PhysAddr, VirtAddr,
 };
 
 pub struct EmptyFrameAllocator;
@@ -34,8 +34,8 @@ pub fn create_example_mapping(
 /// `physical_memory_offset`. Also, this function must be only called once
 /// to avoid aliasing `&mut` references (which is undefined behavior).
 pub unsafe fn init(physical_memory_offset: VirtAddr) -> OffsetPageTable<'static> {
-    let level_4_table = active_level_4_table(physical_memory_offset);
-    OffsetPageTable::new(level_4_table, physical_memory_offset)
+    let level_4_table = unsafe { active_level_4_table(physical_memory_offset) };
+    unsafe { OffsetPageTable::new(level_4_table, physical_memory_offset) }
 }
 
 unsafe fn active_level_4_table(physical_memory_offset: VirtAddr) -> &'static mut PageTable {
@@ -45,5 +45,5 @@ unsafe fn active_level_4_table(physical_memory_offset: VirtAddr) -> &'static mut
     let virt = physical_memory_offset + phys.as_u64();
     let page_table_ptr: *mut PageTable = virt.as_mut_ptr();
 
-    &mut *page_table_ptr // unsafe
+    unsafe { &mut *page_table_ptr } // unsafe
 }

--- a/kernel/src/memory/buddy.rs
+++ b/kernel/src/memory/buddy.rs
@@ -6,8 +6,8 @@
 //! A dense bitmap tracks which frames are free vs. allocated.
 
 use bootloader_api::info::{MemoryRegionKind, MemoryRegions};
-use x86_64::structures::paging::{FrameAllocator, PhysFrame, Size4KiB};
 use x86_64::PhysAddr;
+use x86_64::structures::paging::{FrameAllocator, PhysFrame, Size4KiB};
 
 use crate::monitor;
 

--- a/kernel/src/pic.rs
+++ b/kernel/src/pic.rs
@@ -26,7 +26,9 @@ impl Pic {
     }
 
     unsafe fn end_of_interrupt(&mut self) {
-        self.command.write(CMD_END_OF_INTERRUPT);
+        unsafe {
+            self.command.write(CMD_END_OF_INTERRUPT);
+        }
     }
 }
 
@@ -64,40 +66,42 @@ impl ChainedPics {
     ///
     /// Must be called only once and before enabling interrupts.
     pub unsafe fn initialize(&mut self) {
-        let mut wait_port: Port<u8> = Port::new(0x80);
-        let mut wait = || wait_port.write(0);
+        unsafe {
+            let mut wait_port: Port<u8> = Port::new(0x80);
+            let mut wait = || wait_port.write(0);
 
-        // Save masks
-        let saved_mask1 = self.pics[0].data.read();
-        let saved_mask2 = self.pics[1].data.read();
+            // Save masks
+            let saved_mask1 = self.pics[0].data.read();
+            let saved_mask2 = self.pics[1].data.read();
 
-        // ICW1: start initialization
-        self.pics[0].command.write(CMD_INIT);
-        wait();
-        self.pics[1].command.write(CMD_INIT);
-        wait();
+            // ICW1: start initialization
+            self.pics[0].command.write(CMD_INIT);
+            wait();
+            self.pics[1].command.write(CMD_INIT);
+            wait();
 
-        // ICW2: base offsets
-        self.pics[0].data.write(self.pics[0].offset);
-        wait();
-        self.pics[1].data.write(self.pics[1].offset);
-        wait();
+            // ICW2: base offsets
+            self.pics[0].data.write(self.pics[0].offset);
+            wait();
+            self.pics[1].data.write(self.pics[1].offset);
+            wait();
 
-        // ICW3: chaining (PIC1: slave on IR2, PIC2: cascade identity)
-        self.pics[0].data.write(4);
-        wait();
-        self.pics[1].data.write(2);
-        wait();
+            // ICW3: chaining (PIC1: slave on IR2, PIC2: cascade identity)
+            self.pics[0].data.write(4);
+            wait();
+            self.pics[1].data.write(2);
+            wait();
 
-        // ICW4: 8086 mode
-        self.pics[0].data.write(MODE_8086);
-        wait();
-        self.pics[1].data.write(MODE_8086);
-        wait();
+            // ICW4: 8086 mode
+            self.pics[0].data.write(MODE_8086);
+            wait();
+            self.pics[1].data.write(MODE_8086);
+            wait();
 
-        // Restore masks
-        self.pics[0].data.write(saved_mask1);
-        self.pics[1].data.write(saved_mask2);
+            // Restore masks
+            self.pics[0].data.write(saved_mask1);
+            self.pics[1].data.write(saved_mask2);
+        }
     }
 
     /// Notify the PIC(s) that an interrupt has been handled.
@@ -106,9 +110,11 @@ impl ChainedPics {
     ///
     /// Must be called from the interrupt handler for the given `interrupt_id`.
     pub unsafe fn notify_end_of_interrupt(&mut self, interrupt_id: u8) {
-        if self.pics[1].handles_interrupt(interrupt_id) {
-            self.pics[1].end_of_interrupt();
+        unsafe {
+            if self.pics[1].handles_interrupt(interrupt_id) {
+                self.pics[1].end_of_interrupt();
+            }
+            self.pics[0].end_of_interrupt();
         }
-        self.pics[0].end_of_interrupt();
     }
 }

--- a/kernel/src/sse.rs
+++ b/kernel/src/sse.rs
@@ -7,17 +7,19 @@ use core::arch::asm;
 /// only be called during early kernel initialization before any
 /// floating point operations are executed.
 pub unsafe fn init() {
-    let mut cr0: u64;
-    asm!("mov {}, cr0", out(reg) cr0, options(nostack, preserves_flags));
-    // clear EM (bit 2) and TS (bit 3)
-    cr0 &= !((1 << 2) | (1 << 3));
-    // set MP (bit 1) and NE (bit 5)
-    cr0 |= (1 << 1) | (1 << 5);
-    asm!("mov cr0, {}", in(reg) cr0, options(nostack, preserves_flags));
+    unsafe {
+        let mut cr0: u64;
+        asm!("mov {}, cr0", out(reg) cr0, options(nostack, preserves_flags));
+        // clear EM (bit 2) and TS (bit 3)
+        cr0 &= !((1 << 2) | (1 << 3));
+        // set MP (bit 1) and NE (bit 5)
+        cr0 |= (1 << 1) | (1 << 5);
+        asm!("mov cr0, {}", in(reg) cr0, options(nostack, preserves_flags));
 
-    let mut cr4: u64;
-    asm!("mov {}, cr4", out(reg) cr4, options(nostack, preserves_flags));
-    // set OSFXSR (bit 9) and OSXMMEXCPT (bit 10)
-    cr4 |= (1 << 9) | (1 << 10);
-    asm!("mov cr4, {}", in(reg) cr4, options(nostack, preserves_flags));
+        let mut cr4: u64;
+        asm!("mov {}, cr4", out(reg) cr4, options(nostack, preserves_flags));
+        // set OSFXSR (bit 9) and OSXMMEXCPT (bit 10)
+        cr4 |= (1 << 9) | (1 << 10);
+        asm!("mov cr4, {}", in(reg) cr4, options(nostack, preserves_flags));
+    }
 }

--- a/kernel/src/task/keyboard.rs
+++ b/kernel/src/task/keyboard.rs
@@ -6,7 +6,7 @@ use core::{
     pin::Pin,
     task::{Context, Poll},
 };
-use pc_keyboard::{layouts, DecodedKey, HandleControl, Keyboard, ScancodeSet1};
+use pc_keyboard::{DecodedKey, HandleControl, PS2Keyboard, ScancodeSet1, layouts};
 
 static WAKER: AtomicWaker = AtomicWaker::new();
 static SCANCODE_QUEUE: OnceCell<ArrayQueue<u8>> = OnceCell::uninit();
@@ -28,15 +28,19 @@ pub(crate) fn add_scancode(scancode: u8) {
 
 pub async fn print_keypresses() {
     let mut scancodes = ScancodeStream::new();
-    let mut keyboard = Keyboard::new(layouts::Us104Key, ScancodeSet1, HandleControl::Ignore);
+    let mut keyboard = PS2Keyboard::new(
+        ScancodeSet1::new(),
+        layouts::Us104Key,
+        HandleControl::Ignore,
+    );
 
     while let Some(scancode) = scancodes.next().await {
-        if let Ok(Some(key_event)) = keyboard.add_byte(scancode) {
-            if let Some(key) = keyboard.process_keyevent(key_event) {
-                match key {
-                    DecodedKey::Unicode(character) => print!("{}", character),
-                    DecodedKey::RawKey(key) => print!("{:?}", key),
-                }
+        if let Ok(Some(key_event)) = keyboard.add_byte(scancode)
+            && let Some(key) = keyboard.process_keyevent(key_event)
+        {
+            match key {
+                DecodedKey::Unicode(character) => print!("{}", character),
+                DecodedKey::RawKey(key) => print!("{:?}", key),
             }
         }
     }

--- a/kernel/tests/all.rs
+++ b/kernel/tests/all.rs
@@ -13,7 +13,7 @@ mod file_system;
 #[path = "common/heap_allocation.rs"]
 mod heap_allocation;
 
-use bootloader_api::{entry_point, BootInfo};
+use bootloader_api::{BootInfo, entry_point};
 use core::panic::PanicInfo;
 use x86_64::VirtAddr;
 use yonti_os::allocator;

--- a/kernel/tests/should_panic.rs
+++ b/kernel/tests/should_panic.rs
@@ -1,9 +1,9 @@
 #![no_std]
 #![no_main]
 
-use bootloader_api::{entry_point, BootInfo};
+use bootloader_api::{BootInfo, entry_point};
 use core::panic::PanicInfo;
-use yonti_os::{exit_qemu, serial_print, serial_println, QemuExitCode};
+use yonti_os::{QemuExitCode, exit_qemu, serial_print, serial_println};
 
 entry_point!(test_kernel_main, config = &yonti_os::BOOTLOADER_CONFIG);
 

--- a/kernel/tests/stack_overflow.rs
+++ b/kernel/tests/stack_overflow.rs
@@ -2,11 +2,11 @@
 #![no_main]
 #![feature(abi_x86_interrupt)]
 
-use bootloader_api::{entry_point, BootInfo};
+use bootloader_api::{BootInfo, entry_point};
 use core::panic::PanicInfo;
 use lazy_static::lazy_static;
 use x86_64::structures::idt::{InterruptDescriptorTable, InterruptStackFrame};
-use yonti_os::{exit_qemu, serial_print, serial_println, QemuExitCode};
+use yonti_os::{QemuExitCode, exit_qemu, serial_print, serial_println};
 
 extern "x86-interrupt" fn test_double_fault_handler(
     _stack_frame: InterruptStackFrame,

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "runner"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 
 [workspace]


### PR DESCRIPTION
Upgrades codebase to Rust 2024, fixes pc-keyboard crate compatibility, refactors pattern bindings, wraps unsafe blocks inside unsafe functions, and cleans up clippy warnings.