### PR TITLE
feat: 7 kernel improvements — FS limits, O(1) buddy, ANSI color, shell

### DIFF
--- a/kernel/src/framebuffer.rs
+++ b/kernel/src/framebuffer.rs
@@ -204,6 +204,60 @@ impl FrameBufferWriter {
             }
         }
     }
+
+    pub fn read_pixel(&self, x: usize, y: usize) -> Option<(u8, u8, u8)> {
+        if x >= self.info.width || y >= self.info.height {
+            return None;
+        }
+        let offset = (y * self.info.stride + x) * self.info.bytes_per_pixel;
+        if offset + 2 >= self.buffer.len() {
+            return None;
+        }
+        match self.info.pixel_format {
+            PixelFormat::Rgb => Some((
+                self.buffer[offset],
+                self.buffer[offset + 1],
+                self.buffer[offset + 2],
+            )),
+            PixelFormat::Bgr => Some((
+                self.buffer[offset + 2],
+                self.buffer[offset + 1],
+                self.buffer[offset],
+            )),
+            _ => Some((
+                self.buffer[offset],
+                self.buffer[offset + 1],
+                self.buffer[offset + 2],
+            )),
+        }
+    }
+
+    pub fn cursor_position(&self) -> (usize, usize) {
+        (self.x_pos, self.y_pos)
+    }
+
+    pub fn dimensions(&self) -> (usize, usize) {
+        (self.info.width, self.info.height)
+    }
+
+    pub fn clear_screen(&mut self) {
+        self.buffer.fill(0);
+        self.x_pos = 0;
+        self.y_pos = 0;
+    }
+
+    pub fn set_cursor(&mut self, x: usize, y: usize) {
+        self.x_pos = x;
+        self.y_pos = y;
+    }
+
+    pub fn fg_color(&self) -> (u8, u8, u8) {
+        self.fg
+    }
+
+    pub fn bg_color(&self) -> (u8, u8, u8) {
+        self.bg
+    }
 }
 
 impl fmt::Debug for FrameBufferWriter {
@@ -231,6 +285,22 @@ static FRAMEBUFFER: Mutex<Option<FrameBufferWriter>> = Mutex::new(None);
 pub fn init(buffer: &'static mut [u8], info: FrameBufferInfo) {
     let writer = FrameBufferWriter::new(buffer, info);
     *FRAMEBUFFER.lock() = Some(writer);
+}
+
+pub fn with_framebuffer<F, R>(f: F) -> Option<R>
+where
+    F: FnOnce(&FrameBufferWriter) -> R,
+{
+    use x86_64::instructions::interrupts;
+    interrupts::without_interrupts(|| FRAMEBUFFER.lock().as_ref().map(f))
+}
+
+pub fn with_framebuffer_mut<F, R>(f: F) -> Option<R>
+where
+    F: FnOnce(&mut FrameBufferWriter) -> R,
+{
+    use x86_64::instructions::interrupts;
+    interrupts::without_interrupts(|| FRAMEBUFFER.lock().as_mut().map(f))
 }
 
 pub fn _print(args: fmt::Arguments) {

--- a/kernel/src/framebuffer.rs
+++ b/kernel/src/framebuffer.rs
@@ -4,11 +4,35 @@ use spin::Mutex;
 
 use crate::font::{CHAR_HEIGHT, CHAR_WIDTH, FALLBACK_INDEX, FONT_BASIC, FONT_OFFSET};
 
+const ANSI_COLORS: [(u8, u8, u8); 8] = [
+    (0, 0, 0),
+    (170, 0, 0),
+    (0, 170, 0),
+    (170, 85, 0),
+    (0, 0, 170),
+    (170, 0, 170),
+    (0, 170, 170),
+    (170, 170, 170),
+];
+
+#[derive(Clone, Copy, PartialEq)]
+enum EscapeState {
+    Normal,
+    SawEsc,
+    SawBracket,
+    InCsi,
+}
+
 pub struct FrameBufferWriter {
     buffer: &'static mut [u8],
     info: FrameBufferInfo,
     x_pos: usize,
     y_pos: usize,
+    fg: (u8, u8, u8),
+    bg: (u8, u8, u8),
+    escape_state: EscapeState,
+    csi_buf: [u8; 8],
+    csi_pos: usize,
 }
 
 impl FrameBufferWriter {
@@ -18,6 +42,11 @@ impl FrameBufferWriter {
             info,
             x_pos: 0,
             y_pos: 0,
+            fg: (170, 170, 170),
+            bg: (0, 0, 0),
+            escape_state: EscapeState::Normal,
+            csi_buf: [0; 8],
+            csi_pos: 0,
         }
     }
 
@@ -60,9 +89,9 @@ impl FrameBufferWriter {
             let glyph_byte = FONT_BASIC[glyph_start + row];
             for col in 0..CHAR_WIDTH {
                 if glyph_byte & (1 << (7 - col)) != 0 {
-                    self.write_pixel(x + col, y + row, 255, 255, 255);
+                    self.write_pixel(x + col, y + row, self.fg.0, self.fg.1, self.fg.2);
                 } else {
-                    self.write_pixel(x + col, y + row, 0, 0, 0);
+                    self.write_pixel(x + col, y + row, self.bg.0, self.bg.1, self.bg.2);
                 }
             }
         }
@@ -101,15 +130,68 @@ impl FrameBufferWriter {
         }
     }
 
+    fn apply_sgr(&mut self) {
+        let buf = core::str::from_utf8(&self.csi_buf[..self.csi_pos]).unwrap_or("");
+        let param: u32 = buf
+            .split(';')
+            .next()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0);
+
+        match param {
+            0 => {
+                self.fg = (170, 170, 170);
+                self.bg = (0, 0, 0);
+            }
+            30..=37 => {
+                self.fg = ANSI_COLORS[(param - 30) as usize];
+            }
+            40..=47 => {
+                self.bg = ANSI_COLORS[(param - 40) as usize];
+            }
+            _ => {}
+        }
+    }
+
     pub fn write_byte(&mut self, byte: u8) {
-        match byte {
-            b'\n' => self.new_line(),
-            byte => {
-                if self.x_pos + CHAR_WIDTH > self.info.width {
-                    self.new_line();
+        match self.escape_state {
+            EscapeState::Normal => match byte {
+                0x1b => self.escape_state = EscapeState::SawEsc,
+                b'\n' => self.new_line(),
+                byte => {
+                    if self.x_pos + CHAR_WIDTH > self.info.width {
+                        self.new_line();
+                    }
+                    self.draw_char(self.x_pos, self.y_pos, byte);
+                    self.x_pos += CHAR_WIDTH;
                 }
-                self.draw_char(self.x_pos, self.y_pos, byte);
-                self.x_pos += CHAR_WIDTH;
+            },
+            EscapeState::SawEsc => {
+                self.escape_state = if byte == b'[' {
+                    EscapeState::SawBracket
+                } else {
+                    EscapeState::Normal
+                };
+            }
+            EscapeState::SawBracket => {
+                if byte.is_ascii_digit() || byte == b';' {
+                    self.escape_state = EscapeState::InCsi;
+                    self.csi_buf[0] = byte;
+                    self.csi_pos = 1;
+                } else {
+                    self.escape_state = EscapeState::Normal;
+                }
+            }
+            EscapeState::InCsi => {
+                if (byte.is_ascii_digit() || byte == b';') && self.csi_pos < self.csi_buf.len() {
+                    self.csi_buf[self.csi_pos] = byte;
+                    self.csi_pos += 1;
+                } else if byte == b'm' {
+                    self.apply_sgr();
+                    self.escape_state = EscapeState::Normal;
+                } else {
+                    self.escape_state = EscapeState::Normal;
+                }
             }
         }
     }
@@ -117,7 +199,7 @@ impl FrameBufferWriter {
     pub fn write_string(&mut self, s: &str) {
         for byte in s.bytes() {
             match byte {
-                0x20..=0x7e | b'\n' => self.write_byte(byte),
+                0x20..=0x7e | b'\n' | 0x1b => self.write_byte(byte),
                 _ => self.write_byte(0xfe),
             }
         }

--- a/kernel/src/fs/inode.rs
+++ b/kernel/src/fs/inode.rs
@@ -1,33 +1,35 @@
+use super::FsError;
 use alloc::collections::BTreeMap;
+use alloc::string::String;
 use alloc::vec::Vec;
 
 /// A file containing raw byte data, or a directory containing child inodes.
 #[derive(Debug, Clone)]
 pub enum InodeKind {
     File(Vec<u8>),
-    Directory(BTreeMap<&'static str, Inode>),
+    Directory(BTreeMap<String, Inode>),
 }
 
 /// A node in the filesystem tree, either a file or a directory.
 #[derive(Debug, Clone)]
 pub struct Inode {
-    pub name: &'static str,
+    pub name: String,
     pub kind: InodeKind,
 }
 
 impl Inode {
     /// Create a new empty file inode.
-    pub const fn new_file(name: &'static str) -> Self {
+    pub fn new_file(name: &str) -> Self {
         Inode {
-            name,
+            name: String::from(name),
             kind: InodeKind::File(Vec::new()),
         }
     }
 
     /// Create a new empty directory inode.
-    pub const fn new_directory(name: &'static str) -> Self {
+    pub fn new_directory(name: &str) -> Self {
         Inode {
-            name,
+            name: String::from(name),
             kind: InodeKind::Directory(BTreeMap::new()),
         }
     }
@@ -43,23 +45,23 @@ impl Inode {
     /// Replace the file contents with the given data.
     ///
     /// Returns an error if this inode is a directory.
-    pub fn write(&mut self, data: &[u8]) -> Result<(), &'static str> {
+    pub fn write(&mut self, data: &[u8]) -> Result<(), FsError> {
         match &mut self.kind {
             InodeKind::File(buf) => {
                 *buf = Vec::from(data);
                 Ok(())
             }
-            InodeKind::Directory(_) => Err("cannot write data to a directory"),
+            InodeKind::Directory(_) => Err(FsError::NotAFile),
         }
     }
 
-    pub fn append(&mut self, data: &[u8]) -> Result<(), &'static str> {
+    pub fn append(&mut self, data: &[u8]) -> Result<(), FsError> {
         match &mut self.kind {
             InodeKind::File(buf) => {
                 buf.extend_from_slice(data);
                 Ok(())
             }
-            InodeKind::Directory(_) => Err("cannot append data to a directory"),
+            InodeKind::Directory(_) => Err(FsError::NotAFile),
         }
     }
 
@@ -84,19 +86,17 @@ impl Inode {
         }
     }
 
-    pub fn list_children(&self) -> Vec<&'static str> {
+    pub fn list_children(&self) -> Vec<String> {
         match &self.kind {
-            InodeKind::Directory(children) => children.keys().copied().collect(),
+            InodeKind::Directory(children) => children.keys().cloned().collect(),
             InodeKind::File(_) => Vec::new(),
         }
     }
 
-    pub fn remove_child(&mut self, name: &str) -> Result<Inode, &'static str> {
+    pub fn remove_child(&mut self, name: &str) -> Result<Inode, FsError> {
         match &mut self.kind {
-            InodeKind::Directory(children) => {
-                children.remove(name).ok_or("file/directory not found")
-            }
-            InodeKind::File(_) => Err("cannot remove child from a file"),
+            InodeKind::Directory(children) => children.remove(name).ok_or(FsError::NotFound),
+            InodeKind::File(_) => Err(FsError::NotADirectory),
         }
     }
 }

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -3,6 +3,15 @@
 /// All data is stored in heap-allocated `Vec<u8>` — no disk driver needed.
 /// Thread-safe via `spin::RwLock` around the global [`FS`] instance.
 ///
+/// # Limits
+///
+/// | Resource        | Limit  |
+/// |-----------------|--------|
+/// | Max file size   | 64 KiB |
+/// | Max children/dir| 128    |
+/// | Max path depth  | 16     |
+/// | Max total inodes| 512    |
+///
 /// # Example
 ///
 /// ```ignore
@@ -15,87 +24,130 @@
 /// ```
 pub mod inode;
 
+use alloc::string::String;
 use alloc::vec::Vec;
 use inode::{Inode, InodeKind};
 use spin::RwLock;
 
+const MAX_FILE_SIZE: usize = 65536;
+const MAX_DIR_CHILDREN: usize = 128;
+const MAX_PATH_DEPTH: usize = 16;
+const MAX_TOTAL_INODES: usize = 512;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FsError {
+    NotFound,
+    AlreadyExists,
+    NotAFile,
+    NotADirectory,
+    InvalidPath,
+    FileTooLarge,
+    TooManyChildren,
+    PathTooDeep,
+    TooManyInodes,
+    DirectoryNotEmpty,
+}
+
 #[derive(Debug)]
 pub struct FileSystem {
     root: Inode,
+    inode_count: usize,
 }
 
 impl FileSystem {
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
         FileSystem {
             root: Inode::new_directory("/"),
+            inode_count: 1,
         }
     }
 
-    pub fn create_file(&mut self, path: &'static str) -> Result<(), &'static str> {
+    pub fn create_file(&mut self, path: &str) -> Result<(), FsError> {
+        if self.inode_count >= MAX_TOTAL_INODES {
+            return Err(FsError::TooManyInodes);
+        }
         let (parent, name) = resolve_path(path)?;
         let dir = find_dir_mut(&mut self.root, parent)?;
         if dir.find_child(name).is_some() {
-            return Err("file already exists");
+            return Err(FsError::AlreadyExists);
+        }
+        if dir_child_count(dir) >= MAX_DIR_CHILDREN {
+            return Err(FsError::TooManyChildren);
         }
         match &mut dir.kind {
             InodeKind::Directory(children) => {
-                children.insert(name, Inode::new_file(name));
+                children.insert(String::from(name), Inode::new_file(name));
+                self.inode_count += 1;
                 Ok(())
             }
             _ => unreachable!(),
         }
     }
 
-    pub fn create_dir(&mut self, path: &'static str) -> Result<(), &'static str> {
+    pub fn create_dir(&mut self, path: &str) -> Result<(), FsError> {
+        if self.inode_count >= MAX_TOTAL_INODES {
+            return Err(FsError::TooManyInodes);
+        }
         let (parent, name) = resolve_path(path)?;
         let dir = find_dir_mut(&mut self.root, parent)?;
         if dir.find_child(name).is_some() {
-            return Err("directory already exists");
+            return Err(FsError::AlreadyExists);
+        }
+        if dir_child_count(dir) >= MAX_DIR_CHILDREN {
+            return Err(FsError::TooManyChildren);
         }
         match &mut dir.kind {
             InodeKind::Directory(children) => {
-                children.insert(name, Inode::new_directory(name));
+                children.insert(String::from(name), Inode::new_directory(name));
+                self.inode_count += 1;
                 Ok(())
             }
             _ => unreachable!(),
         }
     }
 
-    pub fn read_file(&self, path: &'static str) -> Result<Vec<u8>, &'static str> {
+    pub fn read_file(&self, path: &str) -> Result<Vec<u8>, FsError> {
         let inode = find_inode(&self.root, path)?;
-        inode.read().map(|d| d.to_vec()).ok_or("not a file")
+        inode.read().map(|d| d.to_vec()).ok_or(FsError::NotAFile)
     }
 
-    /// Write data to a file, replacing any existing contents.
-    pub fn write_file(&mut self, path: &'static str, data: &[u8]) -> Result<(), &'static str> {
+    pub fn write_file(&mut self, path: &str, data: &[u8]) -> Result<(), FsError> {
+        if data.len() > MAX_FILE_SIZE {
+            return Err(FsError::FileTooLarge);
+        }
         let inode = find_inode_mut(&mut self.root, path)?;
         inode.write(data)
     }
 
-    /// Append data to the end of a file.
-    pub fn append_file(&mut self, path: &'static str, data: &[u8]) -> Result<(), &'static str> {
+    pub fn append_file(&mut self, path: &str, data: &[u8]) -> Result<(), FsError> {
         let inode = find_inode_mut(&mut self.root, path)?;
+        let current_len = match &inode.kind {
+            InodeKind::File(buf) => buf.len(),
+            InodeKind::Directory(_) => return Err(FsError::NotAFile),
+        };
+        if current_len.saturating_add(data.len()) > MAX_FILE_SIZE {
+            return Err(FsError::FileTooLarge);
+        }
         inode.append(data)
     }
 
-    /// List the names of all children in a directory.
-    pub fn list_dir(&self, path: &'static str) -> Result<Vec<&'static str>, &'static str> {
+    pub fn list_dir(&self, path: &str) -> Result<Vec<String>, FsError> {
         let inode = find_inode(&self.root, path)?;
         match &inode.kind {
-            InodeKind::Directory(children) => Ok(children.keys().copied().collect()),
-            InodeKind::File(_) => Err("not a directory"),
+            InodeKind::Directory(children) => Ok(children.keys().cloned().collect()),
+            InodeKind::File(_) => Err(FsError::NotADirectory),
         }
     }
 
-    pub fn exists(&self, path: &'static str) -> bool {
+    pub fn exists(&self, path: &str) -> bool {
         find_inode(&self.root, path).is_ok()
     }
 
-    /// Remove a file or directory at the given path.
-    pub fn remove(&mut self, path: &'static str) -> Result<(), &'static str> {
+    pub fn remove(&mut self, path: &str) -> Result<(), FsError> {
         let (parent, name) = resolve_path(path)?;
         let dir = find_dir_mut(&mut self.root, parent)?;
         dir.remove_child(name)?;
+        self.inode_count = self.inode_count.saturating_sub(1);
         Ok(())
     }
 }
@@ -106,41 +158,48 @@ impl Default for FileSystem {
     }
 }
 
-fn find_inode<'a>(root: &'a Inode, path: &'static str) -> Result<&'a Inode, &'static str> {
+fn dir_child_count(dir: &Inode) -> usize {
+    match &dir.kind {
+        InodeKind::Directory(children) => children.len(),
+        _ => 0,
+    }
+}
+
+fn find_inode<'a>(root: &'a Inode, path: &str) -> Result<&'a Inode, FsError> {
     let parts = split_path(path);
+    if parts.len() > MAX_PATH_DEPTH {
+        return Err(FsError::PathTooDeep);
+    }
     let mut current = root;
     for part in &parts {
-        current = current.find_child(part).ok_or("path not found")?;
+        current = current.find_child(part).ok_or(FsError::NotFound)?;
     }
     Ok(current)
 }
 
-fn find_inode_mut<'a>(
-    root: &'a mut Inode,
-    path: &'static str,
-) -> Result<&'a mut Inode, &'static str> {
+fn find_inode_mut<'a>(root: &'a mut Inode, path: &str) -> Result<&'a mut Inode, FsError> {
     let parts = split_path(path);
+    if parts.len() > MAX_PATH_DEPTH {
+        return Err(FsError::PathTooDeep);
+    }
     let mut current = root;
     for part in &parts {
-        current = current.find_child_mut(part).ok_or("path not found")?;
+        current = current.find_child_mut(part).ok_or(FsError::NotFound)?;
     }
     Ok(current)
 }
 
-fn find_dir_mut<'a>(
-    root: &'a mut Inode,
-    path: &'static str,
-) -> Result<&'a mut Inode, &'static str> {
+fn find_dir_mut<'a>(root: &'a mut Inode, path: &str) -> Result<&'a mut Inode, FsError> {
     let dir = find_inode_mut(root, path)?;
     match dir.kind {
         InodeKind::Directory(_) => Ok(dir),
-        InodeKind::File(_) => Err("not a directory"),
+        InodeKind::File(_) => Err(FsError::NotADirectory),
     }
 }
 
-fn resolve_path(path: &'static str) -> Result<(&'static str, &'static str), &'static str> {
+fn resolve_path(path: &str) -> Result<(&str, &str), FsError> {
     if path.is_empty() || path == "/" {
-        return Err("invalid path");
+        return Err(FsError::InvalidPath);
     }
     let path = path.trim_matches('/');
     match path.rfind('/') {
@@ -148,24 +207,28 @@ fn resolve_path(path: &'static str) -> Result<(&'static str, &'static str), &'st
             let parent = &path[..idx];
             let name = &path[idx + 1..];
             if name.is_empty() || name == "." || name == ".." {
-                return Err("invalid path");
+                return Err(FsError::InvalidPath);
             }
             Ok((parent, name))
         }
         None => {
             if path == "." || path == ".." {
-                return Err("invalid path");
+                return Err(FsError::InvalidPath);
             }
             Ok(("", path))
         }
     }
 }
 
-fn split_path(path: &'static str) -> Vec<&'static str> {
+fn split_path(path: &str) -> Vec<&str> {
     path.trim_matches('/')
         .split('/')
         .filter(|s| !s.is_empty())
         .collect()
 }
 
-pub static FS: RwLock<FileSystem> = RwLock::new(FileSystem::new());
+use lazy_static::lazy_static;
+
+lazy_static! {
+    pub static ref FS: RwLock<FileSystem> = RwLock::new(FileSystem::new());
+}

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -23,6 +23,7 @@ pub mod monitor;
 pub mod once_cell;
 pub mod pic;
 pub mod serial;
+pub mod shell;
 pub mod sse;
 pub mod task;
 pub mod trace;

--- a/kernel/src/log.rs
+++ b/kernel/src/log.rs
@@ -40,9 +40,16 @@ impl Log for KernelLogger {
         if !self.enabled(record.metadata()) {
             return;
         }
-        // Output format: [LEVEL] module_path: message\n
+        let color = match record.level() {
+            log::Level::Error => "31",
+            log::Level::Warn => "33",
+            log::Level::Info => "37",
+            log::Level::Debug => "36",
+            log::Level::Trace => "35",
+        };
         serial::_print(format_args!(
-            "[{:<5}] {}: {}\n",
+            "\x1b[{}m[{:<5}]\x1b[0m {}: {}\n",
+            color,
             record.level(),
             record.target(),
             record.args(),

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -14,7 +14,7 @@ use yonti_os::fs;
 use yonti_os::log;
 use yonti_os::memory;
 use yonti_os::println;
-use yonti_os::task::keyboard;
+use yonti_os::shell;
 use yonti_os::task::{Task, executor::Executor};
 use yonti_os::trace;
 
@@ -54,7 +54,7 @@ fn kernel_main(boot_info: &'static mut BootInfo) -> ! {
 
     let mut executor = Executor::new();
     executor.spawn(Task::new(example_task()));
-    executor.spawn(Task::new(keyboard::print_keypresses()));
+    executor.spawn(Task::new(shell::shell_task()));
     executor.run();
 }
 

--- a/kernel/src/memory/buddy.rs
+++ b/kernel/src/memory/buddy.rs
@@ -1,9 +1,11 @@
 //! Buddy physical frame allocator.
 //!
 //! Manages physical pages in power-of-two blocks (order 0 = 4 KiB up to
-//! order 10 = 4 MiB). Free blocks are tracked via a singly-linked list
+//! order 10 = 4 MiB). Free blocks are tracked via a doubly-linked list
 //! threaded through the free pages themselves (zero overhead when allocated).
-//! A dense bitmap tracks which frames are free vs. allocated.
+//! Two `usize` slots in each free block store `next` and `prev` indices,
+//! making removal O(1). A dense bitmap tracks which frames are free vs.
+//! allocated.
 
 use bootloader_api::info::{MemoryRegionKind, MemoryRegions};
 use x86_64::PhysAddr;
@@ -169,47 +171,56 @@ impl BuddyAllocator {
         self.mark_range_free(idx, 1 << order);
 
         let header = self.frame_idx_to_ptr(idx);
-        // Thread the free list through the first page of the block
+        let old_head = self.free_lists[order];
         unsafe {
-            *(header as *mut usize) = self.free_lists[order].unwrap_or(NULL_LINK);
+            *(header as *mut usize) = old_head.unwrap_or(NULL_LINK); // next
+            *((header as *mut usize).add(1)) = NULL_LINK; // prev (head)
+        }
+        if let Some(old) = old_head {
+            let old_header = self.frame_idx_to_ptr(old);
+            unsafe {
+                *((old_header as *mut usize).add(1)) = idx; // old head's prev
+            }
         }
         self.free_lists[order] = Some(idx);
     }
 
     fn pop_free(&mut self, order: usize) -> Option<usize> {
         let idx = self.free_lists[order]?;
-        let next = unsafe { *(self.frame_idx_to_ptr(idx) as *const usize) };
+        let header = self.frame_idx_to_ptr(idx);
+        let next = unsafe { *(header as *const usize) };
+        if next != NULL_LINK {
+            let next_header = self.frame_idx_to_ptr(next);
+            unsafe {
+                *((next_header as *mut usize).add(1)) = NULL_LINK; // new head prev
+            }
+        }
         self.free_lists[order] = if next == NULL_LINK { None } else { Some(next) };
         self.mark_range_allocated(idx, 1 << order);
         Some(idx)
     }
 
     fn remove_free(&mut self, idx: usize, order: usize) {
-        // Walk free list for this order, remove matching entry
-        let mut prev: Option<usize> = None;
-        let mut current = self.free_lists[order];
-
-        while let Some(cur_idx) = current {
-            if cur_idx == idx {
-                let next = unsafe { *(self.frame_idx_to_ptr(cur_idx) as *const usize) };
-                let next = if next == NULL_LINK { None } else { Some(next) };
-                match prev {
-                    Some(p) => unsafe {
-                        *(self.frame_idx_to_ptr(p) as *mut usize) = next.unwrap_or(NULL_LINK);
-                    },
-                    None => {
-                        self.free_lists[order] = next;
-                    }
-                }
-                return;
+        let header = self.frame_idx_to_ptr(idx);
+        let (next, prev) = unsafe {
+            (
+                *(header as *const usize),
+                *((header as *const usize).add(1)),
+            )
+        };
+        if prev != NULL_LINK {
+            let prev_header = self.frame_idx_to_ptr(prev);
+            unsafe {
+                *(prev_header as *mut usize) = next;
             }
-            prev = current;
-            let raw_next = unsafe { *(self.frame_idx_to_ptr(cur_idx) as *const usize) };
-            current = if raw_next == NULL_LINK {
-                None
-            } else {
-                Some(raw_next)
-            };
+        } else {
+            self.free_lists[order] = if next == NULL_LINK { None } else { Some(next) };
+        }
+        if next != NULL_LINK {
+            let next_header = self.frame_idx_to_ptr(next);
+            unsafe {
+                *((next_header as *mut usize).add(1)) = prev;
+            }
         }
     }
 

--- a/kernel/src/monitor.rs
+++ b/kernel/src/monitor.rs
@@ -33,6 +33,9 @@ struct MonitorData {
 
     // Timer (updated by timer ISR)
     timer_ticks: AtomicU64,
+
+    // Executor (wake drops)
+    dropped_wakes: AtomicU64,
 }
 
 impl MonitorData {
@@ -49,6 +52,7 @@ impl MonitorData {
             active_tasks: AtomicUsize::new(0),
             interrupt_counts: [const { AtomicU64::new(0) }; 16],
             timer_ticks: AtomicU64::new(0),
+            dropped_wakes: AtomicU64::new(0),
         }
     }
 }
@@ -124,6 +128,12 @@ pub fn uptime_ticks() -> u64 {
     MONITOR.timer_ticks.load(Ordering::Relaxed)
 }
 
+// ── Executor ───────────────────────────────────────────────────────
+
+pub fn inc_dropped_wake() {
+    MONITOR.dropped_wakes.fetch_add(1, Ordering::Relaxed);
+}
+
 // ── Snapshot ──────────────────────────────────────────────────────
 
 #[derive(Debug)]
@@ -139,6 +149,7 @@ pub struct MetricsSnapshot {
     pub active_tasks: usize,
     pub interrupt_counts: [u64; 16],
     pub timer_ticks: u64,
+    pub dropped_wakes: u64,
 }
 
 pub fn snapshot() -> MetricsSnapshot {
@@ -159,12 +170,13 @@ pub fn snapshot() -> MetricsSnapshot {
         active_tasks: MONITOR.active_tasks.load(Ordering::Relaxed),
         interrupt_counts: irq_counts,
         timer_ticks: MONITOR.timer_ticks.load(Ordering::Relaxed),
+        dropped_wakes: MONITOR.dropped_wakes.load(Ordering::Relaxed),
     }
 }
 
 pub fn dump_to_serial(metrics: &MetricsSnapshot) {
     log::info!(
-        "metrics: alloc={} free={} cur={} peak={} frames={}/{} tasks={}/{}/{} ticks={}",
+        "metrics: alloc={} free={} cur={} peak={} frames={}/{} tasks={}/{}/{} drops={} ticks={}",
         metrics.alloc_count,
         metrics.free_count,
         metrics.current_allocated,
@@ -174,6 +186,7 @@ pub fn dump_to_serial(metrics: &MetricsSnapshot) {
         metrics.tasks_spawned,
         metrics.tasks_completed,
         metrics.active_tasks,
+        metrics.dropped_wakes,
         metrics.timer_ticks,
     );
 

--- a/kernel/src/shell.rs
+++ b/kernel/src/shell.rs
@@ -27,7 +27,6 @@ impl Default for Shell {
 }
 
 impl Shell {
-
     pub fn handle_key(&mut self, key: DecodedKey) {
         match key {
             DecodedKey::Unicode('\n') => {

--- a/kernel/src/shell.rs
+++ b/kernel/src/shell.rs
@@ -1,0 +1,229 @@
+use crate::fs::{self, FsError};
+use crate::monitor;
+use crate::trace;
+use crate::{print, println};
+use alloc::string::String;
+use alloc::vec::Vec;
+use pc_keyboard::{DecodedKey, HandleControl, PS2Keyboard, ScancodeSet1, layouts};
+
+pub struct Shell {
+    buf: [u8; 256],
+    pos: usize,
+}
+
+impl Shell {
+    pub const fn new() -> Self {
+        Self {
+            buf: [0; 256],
+            pos: 0,
+        }
+    }
+}
+
+impl Default for Shell {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Shell {
+
+    pub fn handle_key(&mut self, key: DecodedKey) {
+        match key {
+            DecodedKey::Unicode('\n') => {
+                println!();
+                self.execute();
+                self.print_prompt();
+            }
+            DecodedKey::Unicode('\x08') | DecodedKey::RawKey(pc_keyboard::KeyCode::Backspace) => {
+                self.backspace();
+            }
+            DecodedKey::Unicode(c) if c.is_ascii_graphic() || c == ' ' => {
+                self.push(c);
+            }
+            _ => {}
+        }
+    }
+
+    pub fn print_prompt(&self) {
+        print!("\x1b[32m$ \x1b[0m");
+    }
+
+    fn push(&mut self, c: char) {
+        if self.pos < self.buf.len() {
+            self.buf[self.pos] = c as u8;
+            self.pos += 1;
+            print!("{}", c);
+        }
+    }
+
+    fn backspace(&mut self) {
+        if self.pos > 0 {
+            self.pos -= 1;
+            print!("\x08 \x08");
+        }
+    }
+
+    fn execute(&mut self) {
+        let input = core::str::from_utf8(&self.buf[..self.pos]).unwrap_or("");
+        let input = input.trim();
+        let mut parts = input.split_whitespace();
+        let cmd = parts.next().unwrap_or("");
+
+        match cmd {
+            "help" => self.cmd_help(),
+            "mem" => self.cmd_mem(),
+            "trace" => self.cmd_trace(parts.next()),
+            "ls" => self.cmd_ls(parts.next()),
+            "cat" => self.cmd_cat(parts.next()),
+            "alloc" => self.cmd_alloc(parts.next()),
+            "uptime" => self.cmd_uptime(),
+            "clear" => self.cmd_clear(),
+            "echo" => self.cmd_echo(parts.collect::<Vec<_>>().join(" ")),
+            "" => {}
+            _ => println!("unknown command: {}", cmd),
+        }
+
+        self.pos = 0;
+    }
+
+    fn cmd_help(&self) {
+        println!(
+            "commands: help, mem, trace [n], ls <path>, cat <path>, \
+             alloc <n>, uptime, clear, echo <text>"
+        );
+    }
+
+    fn cmd_mem(&self) {
+        let m = monitor::snapshot();
+        println!(
+            "alloc: {} allocs, {} frees, {} bytes in use (peak: {})",
+            m.alloc_count, m.free_count, m.current_allocated, m.peak_allocated,
+        );
+        println!(
+            "frames: {}/{}  tasks: spawned={} completed={} active={}",
+            m.allocated_frames, m.total_frames, m.tasks_spawned, m.tasks_completed, m.active_tasks,
+        );
+        println!(
+            "dropped wakes: {}  ticks: {}",
+            m.dropped_wakes, m.timer_ticks,
+        );
+        for (i, &count) in m.interrupt_counts.iter().enumerate() {
+            if count > 0 {
+                println!("  irq 0x{:02x}: {}", 0x20 + i as u8, count);
+            }
+        }
+    }
+
+    fn cmd_trace(&self, n_arg: Option<&str>) {
+        let n: usize = n_arg.and_then(|s| s.parse().ok()).unwrap_or(10);
+        println!("dumping last {} trace events to serial...", n);
+        trace::dump_last(n);
+    }
+
+    fn cmd_ls(&self, path: Option<&str>) {
+        let path = path.unwrap_or("/");
+        let fs = fs::FS.read();
+        match fs.list_dir(path) {
+            Ok(children) => {
+                println!("{} ({} entries):", path, children.len());
+                for name in &children {
+                    println!("  {}", name);
+                }
+            }
+            Err(FsError::NotADirectory) => {
+                // Try reading as a file
+                match fs.read_file(path) {
+                    Ok(data) => {
+                        println!("{} (file, {} bytes)", path, data.len());
+                    }
+                    Err(_) => println!("ls: {}: not found", path),
+                }
+            }
+            Err(e) => println!("ls: {}: {:?}", path, e),
+        }
+    }
+
+    fn cmd_cat(&self, path: Option<&str>) {
+        let path = match path {
+            Some(p) => p,
+            None => {
+                println!("cat: missing path");
+                return;
+            }
+        };
+        let fs = fs::FS.read();
+        match fs.read_file(path) {
+            Ok(data) => {
+                if let Ok(text) = core::str::from_utf8(&data) {
+                    print!("{}", text);
+                } else {
+                    println!("(binary file, {} bytes)", data.len());
+                }
+            }
+            Err(FsError::NotAFile) => println!("cat: {}: is a directory", path),
+            Err(e) => println!("cat: {}: {:?}", path, e),
+        }
+    }
+
+    fn cmd_alloc(&self, size_arg: Option<&str>) {
+        let size: usize = match size_arg.and_then(|s| s.parse().ok()) {
+            Some(s) if s > 0 => s,
+            _ => {
+                println!("alloc: invalid size");
+                return;
+            }
+        };
+
+        let layout = core::alloc::Layout::from_size_align(size, 8).unwrap();
+        let ptr = unsafe { alloc::alloc::alloc(layout) };
+        if ptr.is_null() {
+            println!("alloc: allocation of {} bytes failed", size);
+        } else {
+            println!("alloc: {} bytes at {:#018x}", size, ptr as usize);
+            unsafe {
+                alloc::alloc::dealloc(ptr, layout);
+            }
+        }
+    }
+
+    fn cmd_uptime(&self) {
+        println!("uptime: {} ticks", monitor::uptime_ticks());
+    }
+
+    fn cmd_clear(&self) {
+        for _ in 0..50 {
+            println!();
+        }
+    }
+
+    fn cmd_echo(&self, text: String) {
+        if text.is_empty() {
+            println!();
+        } else {
+            println!("{}", text);
+        }
+    }
+}
+
+pub async fn shell_task() {
+    use crate::async_utils::StreamExt;
+    use crate::task::keyboard::ScancodeStream;
+
+    let mut scancodes = ScancodeStream::new();
+    let mut keyboard = PS2Keyboard::new(
+        ScancodeSet1::new(),
+        layouts::Us104Key,
+        HandleControl::Ignore,
+    );
+    let mut shell = Shell::new();
+    shell.print_prompt();
+
+    while let Some(scancode) = scancodes.next().await {
+        if let Ok(Some(key_event)) = keyboard.add_byte(scancode)
+            && let Some(key) = keyboard.process_keyevent(key_event)
+        {
+            shell.handle_key(key);
+        }
+    }
+}

--- a/kernel/src/task/executor.rs
+++ b/kernel/src/task/executor.rs
@@ -6,6 +6,8 @@ use alloc::{collections::BTreeMap, sync::Arc};
 use core::fmt;
 use core::task::{Context, Poll, Waker};
 
+const MAX_TASKS: usize = 100;
+
 impl fmt::Debug for Executor {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Executor")
@@ -23,7 +25,7 @@ impl Executor {
     pub fn new() -> Self {
         Executor {
             tasks: BTreeMap::new(),
-            task_queue: Arc::new(ArrayQueue::new(100)),
+            task_queue: Arc::new(ArrayQueue::new(MAX_TASKS)),
         }
     }
 
@@ -97,7 +99,9 @@ impl TaskWaker {
     }
 
     fn wake_task(&self) {
-        let _ = self.task_queue.push(self.task_id);
+        if self.task_queue.push(self.task_id).is_err() {
+            monitor::inc_dropped_wake();
+        }
     }
 }
 

--- a/kernel/src/task/keyboard.rs
+++ b/kernel/src/task/keyboard.rs
@@ -8,6 +8,8 @@ use core::{
 };
 use pc_keyboard::{DecodedKey, HandleControl, PS2Keyboard, ScancodeSet1, layouts};
 
+const MAX_SCANCODES: usize = 100;
+
 static WAKER: AtomicWaker = AtomicWaker::new();
 static SCANCODE_QUEUE: OnceCell<ArrayQueue<u8>> = OnceCell::uninit();
 
@@ -53,7 +55,7 @@ pub struct ScancodeStream {
 impl ScancodeStream {
     pub fn new() -> Self {
         SCANCODE_QUEUE
-            .try_init_once(|| ArrayQueue::new(100))
+            .try_init_once(|| ArrayQueue::new(MAX_SCANCODES))
             .expect("ScancodeStream::new should only be called once");
         ScancodeStream { _private: () }
     }

--- a/kernel/src/trace.rs
+++ b/kernel/src/trace.rs
@@ -43,7 +43,7 @@ struct TraceBuffer {
 unsafe impl Sync for TraceBuffer {}
 
 static TRACE: TraceBuffer = TraceBuffer {
-    entries: UnsafeCell::new(MaybeUninit::uninit()),
+    entries: UnsafeCell::new(MaybeUninit::zeroed()),
     write_idx: AtomicUsize::new(0),
     overflow_count: AtomicU64::new(0),
     initialized: AtomicU64::new(0),

--- a/kernel/tests/all.rs
+++ b/kernel/tests/all.rs
@@ -14,6 +14,8 @@ mod basic_boot;
 mod buddy_allocator;
 #[path = "common/file_system.rs"]
 mod file_system;
+#[path = "common/framebuffer.rs"]
+mod framebuffer_tests;
 #[path = "common/heap_allocation.rs"]
 mod heap_allocation;
 

--- a/kernel/tests/common/file_system.rs
+++ b/kernel/tests/common/file_system.rs
@@ -16,8 +16,8 @@ fn create_and_list_directory() {
     fs.create_file("/mydir/b").expect("create /mydir/b");
     let list = fs.list_dir("/mydir").expect("list /mydir");
     assert_eq!(list.len(), 2);
-    assert!(list.contains(&"a"));
-    assert!(list.contains(&"b"));
+    assert!(list.contains(&alloc::string::String::from("a")));
+    assert!(list.contains(&alloc::string::String::from("b")));
 }
 
 #[test_case]

--- a/kernel/tests/common/framebuffer.rs
+++ b/kernel/tests/common/framebuffer.rs
@@ -1,0 +1,204 @@
+use yonti_os::font::{CHAR_HEIGHT, CHAR_WIDTH, FALLBACK_INDEX, FONT_BASIC, FONT_OFFSET};
+use yonti_os::framebuffer;
+
+#[test_case]
+fn test_clear_screen() {
+    framebuffer::with_framebuffer_mut(|fb| {
+        fb.clear_screen();
+    });
+
+    let pixels = framebuffer::with_framebuffer(|fb| {
+        let mut samples = [(0u8, 0u8, 0u8); 5];
+        let (w, h) = fb.dimensions();
+        let positions = [(0, 0), (1, 0), (w / 2, h / 2), (w - 1, 0), (0, h - 1)];
+        for (i, &(x, y)) in positions.iter().enumerate() {
+            samples[i] = fb.read_pixel(x, y).unwrap_or((0xff, 0xff, 0xff));
+        }
+        samples
+    });
+
+    assert!(pixels.is_some());
+    for pixel in pixels.unwrap() {
+        assert_eq!(pixel, (0, 0, 0), "pixel should be black after clear");
+    }
+}
+
+#[test_case]
+fn test_char_rendering() {
+    let test_char: u8 = b'A';
+    let glyph_idx = (test_char - FONT_OFFSET as u8) as usize;
+    let glyph_start = glyph_idx * CHAR_HEIGHT;
+
+    framebuffer::with_framebuffer_mut(|fb| {
+        fb.clear_screen();
+        fb.set_cursor(0, 0);
+        fb.write_byte(test_char);
+    });
+
+    let result = framebuffer::with_framebuffer(|fb| {
+        let (fg_r, fg_g, fg_b) = fb.fg_color();
+        let (bg_r, bg_g, bg_b) = fb.bg_color();
+        let (w, h) = fb.dimensions();
+        if w < CHAR_WIDTH || h < CHAR_HEIGHT {
+            return false;
+        }
+
+        let mut all_correct = true;
+        for row in 0..CHAR_HEIGHT {
+            let glyph_byte = FONT_BASIC[glyph_start + row];
+            for col in 0..CHAR_WIDTH {
+                let expected_fg = glyph_byte & (1 << (7 - col)) != 0;
+                let pixel = fb.read_pixel(col, row).unwrap();
+                let expected = if expected_fg {
+                    (fg_r, fg_g, fg_b)
+                } else {
+                    (bg_r, bg_g, bg_b)
+                };
+                if pixel != expected {
+                    all_correct = false;
+                }
+            }
+        }
+        all_correct
+    });
+
+    assert_eq!(result, Some(true), "glyph pixels should match font bitmap");
+}
+
+#[test_case]
+fn test_cursor_advances() {
+    framebuffer::with_framebuffer_mut(|fb| {
+        fb.clear_screen();
+        fb.set_cursor(0, 0);
+        fb.write_byte(b'X');
+    });
+
+    let pos = framebuffer::with_framebuffer(|fb| fb.cursor_position());
+    assert_eq!(pos, Some((CHAR_WIDTH, 0)));
+}
+
+#[test_case]
+fn test_newline() {
+    framebuffer::with_framebuffer_mut(|fb| {
+        fb.clear_screen();
+        fb.set_cursor(0, 0);
+        fb.write_byte(b'X');
+        fb.write_byte(b'\n');
+    });
+
+    let pos = framebuffer::with_framebuffer(|fb| fb.cursor_position());
+    assert_eq!(pos, Some((0, CHAR_HEIGHT)));
+}
+
+#[test_case]
+fn test_line_wrap() {
+    let (width, _) = framebuffer::with_framebuffer(|fb| fb.dimensions()).unwrap();
+
+    framebuffer::with_framebuffer_mut(|fb| {
+        fb.clear_screen();
+        fb.set_cursor(0, 0);
+
+        let chars_per_line = width / CHAR_WIDTH;
+        for _ in 0..chars_per_line {
+            fb.write_byte(b'-');
+        }
+        fb.write_byte(b'!');
+    });
+
+    let pos = framebuffer::with_framebuffer(|fb| fb.cursor_position());
+    assert_eq!(
+        pos,
+        Some((CHAR_WIDTH, CHAR_HEIGHT)),
+        "cursor should wrap to next line when reaching end of row"
+    );
+}
+
+#[test_case]
+fn test_scroll() {
+    let (_, height) = framebuffer::with_framebuffer(|fb| fb.dimensions()).unwrap();
+
+    framebuffer::with_framebuffer_mut(|fb| {
+        fb.clear_screen();
+        fb.set_cursor(0, 0);
+
+        let rows = height / CHAR_HEIGHT;
+        for _ in 0..=rows {
+            fb.write_byte(b'\n');
+        }
+    });
+
+    let pos = framebuffer::with_framebuffer(|fb| fb.cursor_position());
+    let max_y = height - CHAR_HEIGHT;
+    assert_eq!(
+        pos,
+        Some((0, max_y)),
+        "cursor should stay within framebuffer bounds after scrolling"
+    );
+}
+
+#[test_case]
+fn test_ansi_color_reset() {
+    framebuffer::with_framebuffer_mut(|fb| {
+        fb.clear_screen();
+        fb.set_cursor(0, 0);
+        fb.write_string("\x1b[31mR\x1b[0mN");
+    });
+
+    let result = framebuffer::with_framebuffer(|fb| {
+        let pixel_r = fb.read_pixel(0, 0).unwrap();
+        let pixel_n = fb.read_pixel(CHAR_WIDTH, 0).unwrap();
+        (pixel_r, pixel_n)
+    });
+
+    let (pixel_r, pixel_n) = result.unwrap();
+    assert_eq!(
+        pixel_r.0, 170,
+        "red glyph: R channel should be 170 (ANSI red)"
+    );
+    assert_eq!(pixel_r.1, 0, "red glyph: G channel should be 0");
+    assert_eq!(pixel_r.2, 0, "red glyph: B channel should be 0");
+    assert_eq!(
+        pixel_n,
+        (170, 170, 170),
+        "reset produces light gray fg on black bg"
+    );
+}
+
+#[test_case]
+fn test_fallback_character() {
+    framebuffer::with_framebuffer_mut(|fb| {
+        fb.clear_screen();
+        fb.set_cursor(0, 0);
+        fb.write_byte(0x01);
+    });
+
+    let result = framebuffer::with_framebuffer(|fb| {
+        let (fg_r, fg_g, fg_b) = fb.fg_color();
+        let (bg_r, bg_g, bg_b) = fb.bg_color();
+
+        let glyph_start = FALLBACK_INDEX * CHAR_HEIGHT;
+        let mut all_correct = true;
+        for row in 0..CHAR_HEIGHT {
+            let glyph_byte = FONT_BASIC[glyph_start + row];
+            for col in 0..CHAR_WIDTH {
+                let expected_fg = glyph_byte & (1 << (7 - col)) != 0;
+                let pixel = fb.read_pixel(col, row).unwrap();
+                let expected = if expected_fg {
+                    (fg_r, fg_g, fg_b)
+                } else {
+                    (bg_r, bg_g, bg_b)
+                };
+                if pixel != expected {
+                    all_correct = false;
+                }
+            }
+        }
+        all_correct
+    });
+
+    assert_eq!(
+        result,
+        Some(true),
+        "non-printable byte should render as fallback character"
+    );
+}


### PR DESCRIPTION
- fs: FsError enum replaces &'static str errors; size limits (64KiB file, 128 children, 16 depth, 512 inodes)
- buddy: doubly-linked free lists make remove_free O(1)
- trace: zero-initialize buffer to prevent UB on early dump
- monitor: dropped_wakes counter for executor queue overflow
- executor/keyboard: extract MAX_TASKS/MAX_SCANCODES constants
- framebuffer: ANSI SGR escape parser, 8-color support, fg/bg state
- log: color-coded ANSI escapes (red errors, yellow warnings, etc.)
- shell: interactive command interpreter — help, mem, trace, ls, cat, alloc, uptime, clear, echo