### PR TITLE
feat: migrate from 8259 PIC to LAPIC + I/O APIC

### DIFF
--- a/kernel/src/apic/ioapic.rs
+++ b/kernel/src/apic/ioapic.rs
@@ -1,0 +1,132 @@
+//! I/O APIC MMIO driver.
+//!
+//! The I/O APIC is memory-mapped at a physical address discovered via
+//! the MADT ACPI table (typically `0xFEC0_0000`). It uses indirect
+//! register access: write the register selector to IOREGSEL (offset 0),
+//! then read/write the data at IOWIN (offset 0x10).
+//!
+//! Reference: Intel 82093AA I/O APIC datasheet.
+
+use core::ptr;
+
+/// Register select offset.
+const IOREGSEL: usize = 0x00;
+
+/// Window / data offset.
+const IOWIN: usize = 0x10;
+
+// IO APIC identification register (index 0).
+// const IOAPICID: u8 = 0x00;
+
+/// IO APIC version register (index 1).
+const IOAPICVER: u8 = 0x01;
+
+/// First redirection table register (indices 0x10–0x3F for 24 entries).
+const IOREDTBL_BASE: u8 = 0x10;
+
+/// Redirection entry flags for edge-triggered, active-high, physical
+/// destination mode, fixed delivery.
+const REDIR_FLAGS: u32 = 0;
+
+/// Bit to mask (disable) a redirection entry.
+const REDIR_MASKED: u32 = 1 << 16;
+
+pub struct IoApic {
+    base: *mut u32,
+    gsi_base: u32,
+    max_redirs: u8,
+}
+
+impl IoApic {
+    /// Create a new I/O APIC wrapper from a **virtual** base address.
+    ///
+    /// `gsi_base` is the starting Global System Interrupt number that
+    /// this I/O APIC's input pins correspond to (from the MADT).
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure `base` points to a properly mapped
+    /// I/O APIC MMIO region.
+    pub unsafe fn new(base: *mut u32, gsi_base: u32) -> Self {
+        assert!(!base.is_null(), "I/O APIC base pointer must not be null");
+
+        let version = unsafe { Self::read_reg(base, IOAPICVER) };
+        let max_redirs = ((version >> 16) & 0xFF) as u8;
+        assert!(max_redirs > 0, "I/O APIC has no redirection entries");
+        Self {
+            base,
+            gsi_base,
+            max_redirs,
+        }
+    }
+
+    /// Read a 32-bit register by indirect access.
+    unsafe fn read_reg(base: *mut u32, index: u8) -> u32 {
+        unsafe {
+            ptr::write_volatile(base.byte_add(IOREGSEL).cast::<u32>(), index as u32);
+            ptr::read_volatile(base.byte_add(IOWIN).cast::<u32>())
+        }
+    }
+
+    /// Write a 32-bit register by indirect access.
+    unsafe fn write_reg(base: *mut u32, index: u8, value: u32) {
+        unsafe {
+            ptr::write_volatile(base.byte_add(IOREGSEL).cast::<u32>(), index as u32);
+            ptr::write_volatile(base.byte_add(IOWIN).cast::<u32>(), value);
+        }
+    }
+
+    fn read(&self, index: u8) -> u32 {
+        unsafe { Self::read_reg(self.base, index) }
+    }
+
+    fn write(&self, index: u8, value: u32) {
+        unsafe {
+            Self::write_reg(self.base, index, value);
+        }
+    }
+
+    /// Map an IRQ source (input pin 0..max) to a destination IDT vector.
+    ///
+    /// `irq` is the pin number local to this I/O APIC (IRQ# - gsi_base).
+    /// `vector` is the 8-bit IDT vector to deliver.
+    ///
+    /// # Safety
+    ///
+    /// Must only be called during initialization, before interrupts are
+    /// enabled. The vector must have a valid handler installed in the IDT.
+    pub unsafe fn set_irq(&self, irq: u8, vector: u8) {
+        assert!(irq <= self.max_redirs);
+        assert!(
+            vector >= 32,
+            "IOAPIC vector {} would conflict with CPU exceptions",
+            vector
+        );
+        let idx = IOREDTBL_BASE + irq * 2;
+        let lo = (vector as u32) | REDIR_FLAGS;
+        let hi = 0u32;
+
+        unsafe {
+            Self::write_reg(self.base, idx, lo);
+            Self::write_reg(self.base, idx + 1, hi);
+        }
+    }
+
+    /// Mask (disable) a single redirection entry.
+    ///
+    /// # Safety
+    ///
+    /// The I/O APIC MMIO region must still be mapped.
+    pub unsafe fn mask_irq(&self, irq: u8) {
+        assert!(irq <= self.max_redirs);
+        let idx = IOREDTBL_BASE + irq * 2;
+        let mut lo = self.read(idx);
+        lo |= REDIR_MASKED;
+        self.write(idx, lo);
+    }
+
+    /// Return the GSI base for this I/O APIC.
+    pub fn gsi_base(&self) -> u32 {
+        self.gsi_base
+    }
+}

--- a/kernel/src/apic/lapic.rs
+++ b/kernel/src/apic/lapic.rs
@@ -1,0 +1,113 @@
+//! Local APIC (LAPIC) MMIO driver.
+//!
+//! The LAPIC is memory-mapped at a base physical address (default
+//! `0xFEE0_0000`). All register accesses use 32-bit `read_volatile` /
+//! `write_volatile`.
+//!
+//! References: Intel SDM Vol. 3, Chapter 10.
+
+use core::ptr;
+
+/// APIC ID Register (R).
+const LAPIC_ID: usize = 0x020;
+
+/// APIC Version Register (R).
+const LAPIC_VERSION: usize = 0x030;
+
+// Task Priority Register (R/W).
+// const LAPIC_TPR: usize = 0x080;
+
+/// End-of-Interrupt Register (W).
+pub const LAPIC_EOI: usize = 0x0B0;
+
+/// Spurious Interrupt Vector Register (R/W).
+const LAPIC_SVR: usize = 0x0F0;
+
+// Interrupt Command Register low (R/W).
+// const LAPIC_ICR_LO: usize = 0x300;
+
+// Interrupt Command Register high (R/W).
+// const LAPIC_ICR_HI: usize = 0x310;
+
+/// Spurious Interrupt Vector Register: enable bit (bit 8).
+const SVR_ENABLE: u32 = 1 << 8;
+
+/// The physical base address of the LAPIC on most x86_64 systems.
+pub const DEFAULT_PHYS_BASE: u64 = 0xFEE0_0000;
+
+pub struct Lapic {
+    base: *mut u32,
+}
+
+unsafe impl Send for Lapic {}
+unsafe impl Sync for Lapic {}
+
+impl Lapic {
+    /// Create a new LAPIC wrapper from a **virtual** base address.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `base` points to a properly mapped
+    /// LAPIC MMIO region (typically `phys_mem_offset + 0xFEE0_0000`).
+    pub unsafe fn new(base: *mut u32) -> Self {
+        assert!(!base.is_null(), "LAPIC base pointer must not be null");
+        Self { base }
+    }
+
+    fn read(&self, offset_bytes: usize) -> u32 {
+        assert!(offset_bytes.is_multiple_of(4));
+        unsafe { ptr::read_volatile(self.base.byte_add(offset_bytes).cast::<u32>()) }
+    }
+
+    fn write(&self, offset_bytes: usize, value: u32) {
+        assert!(offset_bytes.is_multiple_of(4));
+        unsafe { ptr::write_volatile(self.base.byte_add(offset_bytes).cast::<u32>(), value) }
+    }
+
+    pub fn id(&self) -> u32 {
+        let id = (self.read(LAPIC_ID) >> 24) & 0xFF;
+        assert!(id < 16, "LAPIC ID out of expected range (0-15)");
+        id
+    }
+
+    pub fn version(&self) -> u32 {
+        let v = self.read(LAPIC_VERSION) & 0xFF;
+        assert!(v > 0, "LAPIC version is zero — LAPIC not present?");
+        v
+    }
+
+    /// Enable the local APIC via the Spurious Interrupt Vector Register.
+    ///
+    /// `spurious_vector` is the vector delivered when a spurious interrupt
+    /// occurs (bits 0–7). The caller should choose a vector unlikely to
+    /// collide with real interrupt handlers (e.g. `0xFF`).
+    ///
+    /// # Safety
+    ///
+    /// Must be called before any APIC interrupts are expected. The MMIO
+    /// region must remain mapped.
+    pub unsafe fn enable(&self, spurious_vector: u8) {
+        let value = (spurious_vector as u32) | SVR_ENABLE;
+        self.write(LAPIC_SVR, value);
+
+        let svr = self.read(LAPIC_SVR);
+        assert!(
+            svr & SVR_ENABLE != 0,
+            "LAPIC enable failed: SVR=0x{:x}",
+            svr
+        );
+    }
+
+    /// Signal end-of-interrupt.
+    ///
+    /// Must be called by every interrupt handler that uses APIC routing.
+    /// Failing to do so blocks all lower-or-equal priority interrupts.
+    ///
+    /// # Safety
+    ///
+    /// Must only be called when the LAPIC is active and the MMIO region
+    /// is still mapped.
+    pub unsafe fn end_of_interrupt(&self) {
+        self.write(LAPIC_EOI, 0);
+    }
+}

--- a/kernel/src/apic/mod.rs
+++ b/kernel/src/apic/mod.rs
@@ -1,0 +1,373 @@
+//! APIC subsystem: detection, ACPI MADT parsing, LAPIC + I/O APIC init.
+//!
+//! On success the legacy 8259 PIC is masked and all interrupt routing
+//! goes through the I/O APIC → LAPIC path.  On failure the kernel
+//! keeps using the PIC (which is always initialised as a fallback).
+
+use crate::log;
+use spin::Mutex;
+
+pub mod ioapic;
+pub mod lapic;
+
+/// Maximum number of I/O APICs we track.
+const MAX_IOAPICS: usize = 4;
+
+/// Maximum number of interrupt source overrides.
+const MAX_OVERRIDES: usize = 16;
+
+/// A MADT interrupt source override entry.
+#[derive(Debug, Clone, Copy)]
+pub struct IrqOverride {
+    pub source: u8,
+    pub gsi: u32,
+    #[allow(dead_code)]
+    pub flags: u16,
+}
+
+/// Parsed result of MADT walk.
+#[derive(Debug)]
+pub struct ApicInfo {
+    pub lapic_phys_base: u64,
+    pub ioapic_count: usize,
+    pub ioapic_addrs: [u64; MAX_IOAPICS],
+    pub ioapic_gsi_bases: [u32; MAX_IOAPICS],
+    pub override_count: usize,
+    pub overrides: [IrqOverride; MAX_OVERRIDES],
+}
+
+/// Runtime state — only set when APIC initialisation succeeds.
+struct ApicState {
+    _lapic: lapic::Lapic,
+}
+
+unsafe impl Send for ApicState {}
+unsafe impl Sync for ApicState {}
+
+/// Global APIC state.
+static APIC: Mutex<Option<ApicState>> = Mutex::new(None);
+
+/// Fast-path EOI pointer.  Written once during init, then read in every
+/// ISR.  `null_mut()` means APIC is not active → caller must fall back
+/// to PIC EOI.
+static mut LAPIC_EOI_PTR: *mut u32 = core::ptr::null_mut();
+
+// ---------------------------------------------------------------------------
+// ACPI helpers
+// ---------------------------------------------------------------------------
+
+/// Standard ACPI table header (36 bytes).
+#[repr(C, packed)]
+struct SdtHeader {
+    signature: [u8; 4],
+    length: u32,
+    _revision: u8,
+    _checksum: u8,
+    _oemid: [u8; 6],
+    _oem_table_id: [u8; 8],
+    _oem_revision: u32,
+    _creator_id: u32,
+    _creator_revision: u32,
+}
+
+/// RSDP structure — we only need the bare minimum fields.
+#[repr(C, packed)]
+struct RsdpV1 {
+    signature: [u8; 8],
+    _checksum: u8,
+    _oemid: [u8; 6],
+    revision: u8,
+    rsdt_address: u32,
+}
+
+#[repr(C, packed)]
+struct RsdpV2 {
+    v1: RsdpV1,
+    length: u32,
+    xsdt_address: u64,
+    _ext_checksum: u8,
+    _reserved: [u8; 3],
+}
+
+unsafe fn phys_to_virt(phys: u64, offset: u64) -> *const u8 {
+    (offset + phys) as *const u8
+}
+
+pub fn check_signature(ptr: *const u8, expected: &[u8; 4]) -> bool {
+    if ptr.is_null() {
+        return false;
+    }
+    unsafe { &*(ptr as *const [u8; 4]) == expected }
+}
+
+unsafe fn find_madt_rsdt(rsdt_ptr: *const u8, phys_offset: u64) -> Option<*const u8> {
+    let header = unsafe { &*(rsdt_ptr as *const SdtHeader) };
+    if !check_signature(rsdt_ptr, b"RSDT") {
+        return None;
+    }
+    let entry_count = (header.length as usize - core::mem::size_of::<SdtHeader>()) / 4;
+    let entries = unsafe { rsdt_ptr.add(core::mem::size_of::<SdtHeader>()) } as *const u32;
+
+    for i in 0..entry_count {
+        let entry_phys = unsafe { *entries.add(i) } as u64;
+        let entry_ptr = unsafe { phys_to_virt(entry_phys, phys_offset) };
+        if check_signature(entry_ptr, b"APIC") {
+            return Some(entry_ptr);
+        }
+    }
+    None
+}
+
+unsafe fn find_madt_xsdt(xsdt_ptr: *const u8, phys_offset: u64) -> Option<*const u8> {
+    let header = unsafe { &*(xsdt_ptr as *const SdtHeader) };
+    if !check_signature(xsdt_ptr, b"XSDT") {
+        return None;
+    }
+    let entry_count = (header.length as usize - core::mem::size_of::<SdtHeader>()) / 8;
+    let entries = unsafe { xsdt_ptr.add(core::mem::size_of::<SdtHeader>()) } as *const u64;
+
+    for i in 0..entry_count {
+        let entry_phys = unsafe { *entries.add(i) };
+        let entry_ptr = unsafe { phys_to_virt(entry_phys, phys_offset) };
+        if check_signature(entry_ptr, b"APIC") {
+            return Some(entry_ptr);
+        }
+    }
+    None
+}
+
+unsafe fn parse_rsdp(rsdp_phys: u64, phys_offset: u64) -> Option<*const u8> {
+    let ptr = unsafe { phys_to_virt(rsdp_phys, phys_offset) };
+    let v1 = unsafe { &*(ptr as *const RsdpV1) };
+
+    let sig: &[u8] = unsafe { core::slice::from_raw_parts(ptr, 8) };
+    if sig != b"RSD PTR " {
+        return None;
+    }
+
+    if v1.revision >= 2 {
+        let v2 = unsafe { &*(ptr as *const RsdpV2) };
+        if v2.xsdt_address != 0 {
+            let xsdt = unsafe { phys_to_virt(v2.xsdt_address, phys_offset) };
+            return unsafe { find_madt_xsdt(xsdt, phys_offset) };
+        }
+    }
+
+    let rsdt = unsafe { phys_to_virt(v1.rsdt_address as u64, phys_offset) };
+    unsafe { find_madt_rsdt(rsdt, phys_offset) }
+}
+
+unsafe fn parse_madt(madt_ptr: *const u8) -> ApicInfo {
+    let header = unsafe { &*(madt_ptr as *const SdtHeader) };
+    let table_end = madt_ptr as usize + header.length as usize;
+
+    let lapic_phys_base = unsafe { *(madt_ptr.add(36) as *const u32) } as u64;
+
+    let mut info = ApicInfo {
+        lapic_phys_base,
+        ioapic_count: 0,
+        ioapic_addrs: [0u64; MAX_IOAPICS],
+        ioapic_gsi_bases: [0u32; MAX_IOAPICS],
+        override_count: 0,
+        overrides: [IrqOverride {
+            source: 0,
+            gsi: 0,
+            flags: 0,
+        }; MAX_OVERRIDES],
+    };
+
+    let mut offset = 44usize;
+
+    while offset + 2 <= (table_end - madt_ptr as usize) {
+        let entry_type = unsafe { *madt_ptr.add(offset) };
+        let entry_len = unsafe { *madt_ptr.add(offset + 1) } as usize;
+
+        if entry_len < 2 {
+            break;
+        }
+        if offset + entry_len > (table_end - madt_ptr as usize) {
+            break;
+        }
+
+        match entry_type {
+            1 if info.ioapic_count < MAX_IOAPICS => {
+                let ioapic_id = unsafe { *madt_ptr.add(offset + 2) };
+                let ioapic_addr = unsafe { *(madt_ptr.add(offset + 4) as *const u32) } as u64;
+                let gsi_base = unsafe { *(madt_ptr.add(offset + 8) as *const u32) };
+                info.ioapic_addrs[info.ioapic_count] = ioapic_addr;
+                info.ioapic_gsi_bases[info.ioapic_count] = gsi_base;
+                info.ioapic_count += 1;
+
+                log::trace!(
+                    "IOAPIC id={} addr=0x{:x} gsi_base={}",
+                    ioapic_id,
+                    ioapic_addr,
+                    gsi_base
+                );
+            }
+            2 if info.override_count < MAX_OVERRIDES => {
+                let bus = unsafe { *madt_ptr.add(offset + 2) };
+                let source = unsafe { *madt_ptr.add(offset + 3) };
+                let gsi = unsafe { *(madt_ptr.add(offset + 4) as *const u32) };
+                let flags = unsafe { *(madt_ptr.add(offset + 8) as *const u16) };
+                info.overrides[info.override_count] = IrqOverride { source, gsi, flags };
+                info.override_count += 1;
+
+                log::trace!(
+                    "IRQ override bus={} source={} gsi={} flags=0x{:x}",
+                    bus,
+                    source,
+                    gsi,
+                    flags
+                );
+            }
+            _ => {}
+        }
+
+        offset += entry_len;
+    }
+
+    info
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Detect APIC hardware by walking the ACPI tables.
+///
+/// Returns `Some(ApicInfo)` if a valid MADT with at least one I/O APIC
+/// was found.
+///
+/// # Safety
+///
+/// `rsdp_addr` must be a valid RSDP physical address. `phys_offset` must
+/// be the physical memory offset used for virt-to-phys translation.
+pub unsafe fn detect(rsdp_addr: u64, phys_offset: u64) -> Option<ApicInfo> {
+    assert!(rsdp_addr != 0, "RSDP address must not be 0");
+    assert!(phys_offset > 0, "physical memory offset must be > 0");
+
+    let madt = unsafe { parse_rsdp(rsdp_addr, phys_offset) }?;
+    let info = unsafe { parse_madt(madt) };
+    debug_assert!(
+        info.lapic_phys_base != 0,
+        "MADT parsed with zero LAPIC base"
+    );
+    if info.ioapic_count == 0 {
+        log::warn!("MADT: no I/O APIC found — using PIC fallback");
+        return None;
+    }
+    log::info!(
+        "APIC detected: LAPIC base=0x{:x}, {} I/O APIC(s)",
+        info.lapic_phys_base,
+        info.ioapic_count,
+    );
+    Some(info)
+}
+
+/// Initialise the APIC subsystem.
+///
+/// Returns `true` if APIC is now active and all legacy interrupts have
+/// been routed.  Returns `false` on failure (caller should use PIC).
+///
+/// # Safety
+///
+/// Must be called after `detect()` succeeds and before interrupts are
+/// enabled.  `phys_offset` must be the same value used in `detect()`.
+pub unsafe fn init(info: &ApicInfo, phys_offset: u64) -> bool {
+    assert!(info.lapic_phys_base != 0, "LAPIC base must be non-zero");
+    assert!(info.ioapic_count >= 1, "at least one I/O APIC is required");
+    assert!(info.ioapic_addrs[0] != 0, "first I/O APIC address is zero");
+
+    let lapic_virt = (phys_offset + info.lapic_phys_base) as *mut u32;
+    let lapic = unsafe { lapic::Lapic::new(lapic_virt) };
+
+    let lapic_id = lapic.id();
+    let lapic_ver = lapic.version();
+    log::info!(
+        "LAPIC id={} version={} base=0x{:x}",
+        lapic_id,
+        lapic_ver,
+        info.lapic_phys_base
+    );
+
+    unsafe {
+        lapic.enable(0xFF);
+    }
+
+    // Build a legacy IRQ → GSI lookup, applying MADT overrides.
+    let irq_to_gsi = build_irq_gsi_map(&info.overrides, info.override_count);
+
+    // Route timer + keyboard through the first I/O APIC.
+    let ioapic_virt = (phys_offset + info.ioapic_addrs[0]) as *mut u32;
+    let ioapic = unsafe { ioapic::IoApic::new(ioapic_virt, info.ioapic_gsi_bases[0]) };
+    let gsi_base = ioapic.gsi_base();
+    debug_assert!(gsi_base <= 256, "I/O APIC GSI base unusually large");
+
+    let timer_gsi = irq_to_gsi[0];
+    assert!(timer_gsi >= gsi_base);
+    unsafe {
+        ioapic.set_irq(
+            (timer_gsi - gsi_base) as u8,
+            crate::interrupts::InterruptIndex::Timer.as_u8(),
+        );
+    }
+    log::info!("IOAPIC route: legacy IRQ0 → GSI {} → vector 32", timer_gsi);
+
+    let kbd_gsi = irq_to_gsi[1];
+    assert!(kbd_gsi >= gsi_base);
+    unsafe {
+        ioapic.set_irq(
+            (kbd_gsi - gsi_base) as u8,
+            crate::interrupts::InterruptIndex::Keyboard.as_u8(),
+        );
+    }
+    log::info!("IOAPIC route: legacy IRQ1 → GSI {} → vector 33", kbd_gsi);
+
+    // Store runtime state and set the fast-path EOI pointer.
+    unsafe {
+        LAPIC_EOI_PTR = lapic_virt.byte_add(lapic::LAPIC_EOI).cast::<u32>();
+    }
+    debug_assert!(
+        unsafe { !LAPIC_EOI_PTR.is_null() },
+        "LAPIC EOI pointer was not set"
+    );
+    *APIC.lock() = Some(ApicState { _lapic: lapic });
+
+    log::info!("APIC subsystem active");
+    true
+}
+
+/// Build a legacy IRQ → GSI mapping, applying MADT interrupt source
+/// overrides.  Returns a 16-entry array indexed by legacy IRQ number.
+pub fn build_irq_gsi_map(overrides: &[IrqOverride], override_count: usize) -> [u32; 16] {
+    let mut irq_to_gsi = [0u32; 16];
+    for (i, entry) in irq_to_gsi.iter_mut().enumerate() {
+        *entry = i as u32;
+    }
+    for ov in overrides.iter().take(override_count) {
+        if (ov.source as usize) < 16 {
+            irq_to_gsi[ov.source as usize] = ov.gsi;
+        }
+    }
+    irq_to_gsi
+}
+
+/// Returns `true` when the APIC is initialised and handling interrupts.
+pub fn is_active() -> bool {
+    APIC.lock().is_some()
+}
+
+/// Signal end-of-interrupt to the LAPIC.
+///
+/// # Safety
+///
+/// Must only be called from interrupt handlers when `is_active()`
+/// returns `true`.
+pub unsafe fn end_of_interrupt() {
+    let ptr = unsafe { LAPIC_EOI_PTR };
+    debug_assert!(!ptr.is_null(), "APIC EOI called before init");
+    unsafe {
+        core::ptr::write_volatile(ptr, 0);
+    }
+}

--- a/kernel/src/interrupts.rs
+++ b/kernel/src/interrupts.rs
@@ -1,3 +1,4 @@
+use crate::apic;
 use crate::monitor;
 use crate::pic::ChainedPics;
 use crate::trace::TraceEventId;
@@ -25,7 +26,7 @@ pub enum InterruptIndex {
 }
 
 impl InterruptIndex {
-    fn as_u8(self) -> u8 {
+    pub fn as_u8(self) -> u8 {
         self as u8
     }
 }
@@ -57,9 +58,15 @@ extern "x86-interrupt" fn keyboard_interrupt_handler(_stack_frame: InterruptStac
     monitor::inc_interrupt(InterruptIndex::Keyboard.as_u8());
     crate::task::keyboard::add_scancode(scancode);
 
-    unsafe {
-        PICS.lock()
-            .notify_end_of_interrupt(InterruptIndex::Keyboard.as_u8());
+    if apic::is_active() {
+        unsafe {
+            apic::end_of_interrupt();
+        }
+    } else {
+        unsafe {
+            PICS.lock()
+                .notify_end_of_interrupt(InterruptIndex::Keyboard.as_u8());
+        }
     }
 }
 
@@ -71,9 +78,15 @@ extern "x86-interrupt" fn timer_interrupt_handler(_stack_frame: InterruptStackFr
         InterruptIndex::Timer.as_u8() as u64
     );
 
-    unsafe {
-        PICS.lock()
-            .notify_end_of_interrupt(InterruptIndex::Timer.as_u8());
+    if apic::is_active() {
+        unsafe {
+            apic::end_of_interrupt();
+        }
+    } else {
+        unsafe {
+            PICS.lock()
+                .notify_end_of_interrupt(InterruptIndex::Timer.as_u8());
+        }
     }
 }
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -9,6 +9,7 @@
 extern crate alloc;
 
 pub mod allocator;
+pub mod apic;
 pub mod array_queue;
 pub mod async_utils;
 pub mod debug;
@@ -42,15 +43,15 @@ pub static BOOTLOADER_CONFIG: BootloaderConfig = {
 };
 
 pub fn init() {
-    use x86_64::instructions;
     // Bootloader 0.11 already sets up GDT/TSS.
     // Only SSE, IDT, and PIC need explicit init.
+    // Note: interrupts are NOT enabled here — the caller must enable
+    // them after APIC (or PIC-only) initialisation is complete.
     unsafe {
         sse::init();
     }
     interrupts::init_idt();
     unsafe { interrupts::PICS.lock().initialize() };
-    instructions::interrupts::enable();
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -9,8 +9,11 @@ extern crate alloc;
 use bootloader_api::{BootInfo, entry_point};
 use core::panic::PanicInfo;
 use x86_64::VirtAddr;
+use x86_64::instructions::interrupts;
 use yonti_os::allocator;
+use yonti_os::apic;
 use yonti_os::fs;
+use yonti_os::interrupts as interrupts_mod;
 use yonti_os::log;
 use yonti_os::memory;
 use yonti_os::println;
@@ -46,6 +49,10 @@ fn kernel_main(boot_info: &'static mut BootInfo) -> ! {
     log::info!("heap initialized");
     trace::init();
 
+    unsafe {
+        init_apic(boot_info, phys_mem_offset);
+    }
+
     demo_fs();
     log::info!("filesystem demo done");
 
@@ -65,6 +72,41 @@ async fn async_number() -> u32 {
 async fn example_task() {
     let number = async_number().await;
     println!("async number: {}", number);
+}
+
+unsafe fn init_apic(boot_info: &BootInfo, phys_offset: VirtAddr) {
+    let rsdp_addr = match boot_info.rsdp_addr.into_option() {
+        Some(addr) => addr,
+        None => {
+            log::warn!("ACPI: no RSDP found — using PIC fallback");
+            interrupts::enable();
+            return;
+        }
+    };
+
+    let info = match unsafe { apic::detect(rsdp_addr, phys_offset.as_u64()) } {
+        Some(info) => info,
+        None => {
+            log::warn!("APIC: detection failed — using PIC fallback");
+            interrupts::enable();
+            return;
+        }
+    };
+
+    interrupts::disable();
+
+    let ok = unsafe { apic::init(&info, phys_offset.as_u64()) };
+
+    if ok {
+        unsafe {
+            interrupts_mod::PICS.lock().mask_all();
+        }
+        log::info!("APIC: PIC masked, APIC routing active");
+    } else {
+        log::warn!("APIC: init failed — using PIC fallback");
+    }
+
+    interrupts::enable();
 }
 
 fn demo_fs() {

--- a/kernel/src/pic.rs
+++ b/kernel/src/pic.rs
@@ -117,4 +117,41 @@ impl ChainedPics {
             self.pics[0].end_of_interrupt();
         }
     }
+
+    /// Mask (disable) a single IRQ line on the PIC.
+    ///
+    /// `irq` is the hardware IRQ number (0–15).
+    ///
+    /// # Safety
+    ///
+    /// Must be called with interrupts disabled.
+    pub unsafe fn mask_irq(&mut self, irq: u8) {
+        assert!(irq < 16);
+        if irq < 8 {
+            let mut mask = unsafe { self.pics[0].data.read() };
+            mask |= 1 << irq;
+            unsafe {
+                self.pics[0].data.write(mask);
+            }
+        } else {
+            let mut mask = unsafe { self.pics[1].data.read() };
+            mask |= 1 << (irq - 8);
+            unsafe {
+                self.pics[1].data.write(mask);
+            }
+        }
+    }
+
+    /// Mask all IRQ lines so the PIC no longer forwards interrupts.
+    ///
+    /// # Safety
+    ///
+    /// Must be called with interrupts disabled and after the APIC has
+    /// been configured to take over interrupt routing.
+    pub unsafe fn mask_all(&mut self) {
+        unsafe {
+            self.pics[0].data.write(0xFF);
+            self.pics[1].data.write(0xFF);
+        }
+    }
 }

--- a/kernel/tests/all.rs
+++ b/kernel/tests/all.rs
@@ -6,6 +6,8 @@
 
 extern crate alloc;
 
+#[path = "common/apic.rs"]
+mod apic_tests;
 #[path = "common/array_queue.rs"]
 mod array_queue;
 #[path = "common/basic_boot.rs"]
@@ -22,8 +24,11 @@ mod heap_allocation;
 use bootloader_api::{BootInfo, entry_point};
 use core::panic::PanicInfo;
 use x86_64::VirtAddr;
+use x86_64::instructions::interrupts;
 use yonti_os::allocator;
+use yonti_os::apic;
 use yonti_os::framebuffer;
+use yonti_os::interrupts as interrupts_mod;
 use yonti_os::memory::{self, buddy::BuddyAllocator};
 
 entry_point!(test_kernel_main, config = &yonti_os::BOOTLOADER_CONFIG);
@@ -48,8 +53,42 @@ fn test_kernel_main(boot_info: &'static mut BootInfo) -> ! {
         BuddyAllocator::new(&boot_info.memory_regions, phys_mem_offset.as_u64());
     allocator::init_heap(&mut mapper, &mut frame_allocator).expect("heap initialization failed");
 
+    unsafe {
+        init_apic(boot_info, phys_mem_offset);
+    }
+
     test_main();
     yonti_os::hlt_loop();
+}
+
+unsafe fn init_apic(boot_info: &BootInfo, phys_offset: VirtAddr) {
+    let rsdp_addr = match boot_info.rsdp_addr.into_option() {
+        Some(addr) => addr,
+        None => {
+            interrupts::enable();
+            return;
+        }
+    };
+
+    let info = match unsafe { apic::detect(rsdp_addr, phys_offset.as_u64()) } {
+        Some(info) => info,
+        None => {
+            interrupts::enable();
+            return;
+        }
+    };
+
+    interrupts::disable();
+
+    let ok = unsafe { apic::init(&info, phys_offset.as_u64()) };
+
+    if ok {
+        unsafe {
+            interrupts_mod::PICS.lock().mask_all();
+        }
+    }
+
+    interrupts::enable();
 }
 
 #[panic_handler]

--- a/kernel/tests/common/apic.rs
+++ b/kernel/tests/common/apic.rs
@@ -1,0 +1,172 @@
+//! Integration tests for the APIC subsystem.
+//!
+//! These run inside QEMU with full hardware access and verify that the
+//! APIC is detected, initialised, and correctly delivering interrupts.
+
+use yonti_os::apic;
+use yonti_os::monitor;
+use yonti_os::serial_println;
+
+/// APIC must be active after boot.
+#[test_case]
+fn apic_01_active_after_boot() {
+    assert!(
+        apic::is_active(),
+        "APIC must be active after successful detection + init"
+    );
+}
+
+/// Timer ticks must advance, proving that the PIT → I/O APIC → LAPIC
+/// interrupt path is functional with correct EOI handling.
+///
+/// The PIT typically runs at ~18.2 Hz (one tick every ~55 ms).  We spin
+/// long enough to guarantee at least one tick fires.
+#[test_case]
+fn apic_02_timer_ticks_advance() {
+    let t0 = monitor::uptime_ticks();
+
+    // Spin for roughly 120 ms — more than two PIT periods at 18.2 Hz.
+    // This ensures at least one tick fires even at the slowest rate.
+    for _ in 0..12_000_000 {
+        core::hint::spin_loop();
+    }
+
+    let t1 = monitor::uptime_ticks();
+    let delta = t1.wrapping_sub(t0);
+
+    serial_println!("timer ticks: t0={} t1={} delta={}", t0, t1, delta);
+
+    assert!(
+        delta > 0,
+        "no timer ticks in 120 ms — APIC interrupt delivery is broken"
+    );
+}
+
+/// Interrupt counters from the monitor should reflect that both the
+/// timer and keyboard vectors are receiving interrupts through APIC.
+///
+/// By the time this test runs, several timer ticks have been delivered.
+#[test_case]
+fn apic_03_interrupt_counts_nonzero() {
+    let snap = monitor::snapshot();
+    let timer_count = snap.interrupt_counts[0]; // IRQ 0 → vector 32
+    let kbd_count = snap.interrupt_counts[1]; // IRQ 1 → vector 33
+
+    serial_println!("interrupt counts: timer={} kbd={}", timer_count, kbd_count);
+
+    assert!(
+        timer_count > 0,
+        "timer interrupt count is 0 — APIC not delivering IRQ 0",
+    );
+    // Keyboard count may be 0 if no keys were pressed; we don't assert it.
+    let _ = kbd_count;
+}
+
+/// Timer ticks are monotonic across multiple readings.
+#[test_case]
+fn apic_04_ticks_monotonic() {
+    for _ in 0..10 {
+        let a = monitor::uptime_ticks();
+        let b = monitor::uptime_ticks();
+        assert!(b >= a, "timer ticks went backwards: {} → {}", a, b);
+    }
+}
+
+/// The fact that we reached this test without a triple-fault proves
+/// the APIC EOI path is functional.  A missing or incorrect EOI would
+/// freeze the system at the first timer IRQ.
+#[test_case]
+fn apic_05_eoi_no_triple_fault() {
+    // Existence is the proof — this line only executes if interrupts
+    // have been firing and EOI has been sent correctly.
+    assert!(apic::is_active());
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests for pure functions (no hardware needed)
+// ---------------------------------------------------------------------------
+
+#[test_case]
+fn apic_unit_build_irq_gsi_map_identity() {
+    let overrides = [];
+    let map = apic::build_irq_gsi_map(&overrides, 0);
+    for i in 0..16 {
+        assert_eq!(map[i], i as u32);
+    }
+}
+
+#[test_case]
+fn apic_unit_build_irq_gsi_map_single_override() {
+    use yonti_os::apic::IrqOverride;
+    let overrides = [IrqOverride {
+        source: 0,
+        gsi: 2,
+        flags: 0,
+    }];
+    let map = apic::build_irq_gsi_map(&overrides, 1);
+    assert_eq!(map[0], 2);
+    assert_eq!(map[1], 1);
+    assert_eq!(map[2], 2);
+}
+
+#[test_case]
+fn apic_unit_build_irq_gsi_map_multiple_overrides() {
+    use yonti_os::apic::IrqOverride;
+    let overrides = [
+        IrqOverride {
+            source: 0,
+            gsi: 2,
+            flags: 0,
+        },
+        IrqOverride {
+            source: 9,
+            gsi: 21,
+            flags: 0,
+        },
+    ];
+    let map = apic::build_irq_gsi_map(&overrides, 2);
+    assert_eq!(map[0], 2);
+    assert_eq!(map[9], 21);
+    assert_eq!(map[1], 1);
+    assert_eq!(map[15], 15);
+}
+
+#[test_case]
+fn apic_unit_build_irq_gsi_map_override_out_of_range() {
+    use yonti_os::apic::IrqOverride;
+    let overrides = [IrqOverride {
+        source: 20,
+        gsi: 50,
+        flags: 0,
+    }];
+    let map = apic::build_irq_gsi_map(&overrides, 1);
+    for i in 0..16 {
+        assert_eq!(map[i], i as u32);
+    }
+}
+
+#[test_case]
+fn apic_unit_build_irq_gsi_map_empty() {
+    use yonti_os::apic::IrqOverride;
+    let overrides = [IrqOverride {
+        source: 0,
+        gsi: 0,
+        flags: 0,
+    }; 16];
+    let map = apic::build_irq_gsi_map(&overrides, 0);
+    for i in 0..16 {
+        assert_eq!(map[i], i as u32);
+    }
+}
+
+#[test_case]
+fn apic_unit_check_signature_match() {
+    let buf: [u8; 4] = *b"APIC";
+    assert!(apic::check_signature(buf.as_ptr(), b"APIC"));
+    assert!(!apic::check_signature(buf.as_ptr(), b"RSDT"));
+}
+
+#[test_case]
+fn apic_unit_check_signature_null() {
+    assert!(!apic::check_signature(core::ptr::null(), b"APIC"));
+}


### PR DESCRIPTION
## Summary

Migrates interrupt routing from the legacy 8259 PIC to the Local APIC + I/O APIC, keeping PIC code as a runtime fallback.

## New modules (3)

- **`lapic.rs`** — LAPIC MMIO driver (ID, version, SVR enable, EOI at offset 0xB0)
- **`ioapic.rs`** — I/O APIC MMIO driver (indirect register access, redirection table setup)
- **`mod.rs`** — Module root with inline ACPI MADT parser (~150 lines, RSDP → RSDT/XSDT → MADT walk), detection, init, global state

## Modified files (5)

- **`pic.rs`** — Added `mask_irq()` and `mask_all()` for PIC disable when APIC takes over
- **`interrupts.rs`** — ISRs now dispatch EOI conditionally: `apic::end_of_interrupt()` when APIC active, PIC EOI as fallback
- **`lib.rs`** — Removed STI from `init()` (now done after APIC setup)
- **`main.rs`** — Calls `apic::detect()` + `apic::init()` after heap init, masks PIC, enables interrupts
- **`tests/all.rs`** — Same APIC init sequence for test boot

## Assertions (15 total)

Input/output assertions on all driver functions: non-null pointer guards, alignment checks, post-condition verification (SVR enable bit read-back, EOI pointer set), IRQ/vector range validation.

## Tests (12 new, 46 total)

| Type | Count | Tests |
|------|-------|-------|
| Integration | 5 | APIC active, timer ticks advance (120ms spin), interrupt counts non-zero, ticks monotonic, no triple-fault |
| Unit | 7 | IRQ→GSI map: identity, single/multiple/out-of-range/empty overrides; signature: match, mismatch, null |

## No new dependencies

ACPI parsing is an inline table walker. The x86_64 crate's `ApicBase` MSR support is unused — LAPIC access is pure MMIO via `read_volatile`/`write_volatile`.