### PR TITLE
feat: add GUI mode to QEMU runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,17 @@ sudo apt install qemu-system-x86
 # Build kernel ELF
 cd kernel && cargo build --target x86_64-unknown-none
 
-# Run in QEMU (BIOS mode)
+# Run in QEMU (BIOS mode, headless — serial console only)
 cd runner && cargo run --bin runner -- bios
 
+# Run in QEMU (BIOS mode, GUI — opens QEMU window with framebuffer)
+cd runner && cargo run --bin runner -- gui
 
+# Run with UEFI (headless)
+cd runner && cargo run --bin runner -- uefi
+
+# Enable the QEMU display window in any mode
+cd runner && cargo run --bin runner -- bios --display
 ```
 
 ## Test

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -8,51 +8,55 @@ fn main() {
     let bios_img = env!("BIOS_IMG");
     let uefi_img = env!("UEFI_IMG");
 
+    let no_graphic = !std::env::args().any(|a| a == "--display");
+
     match mode.as_str() {
-        "bios" => run_bios(bios_img),
-        "uefi" => run_uefi(uefi_img),
+        "bios" => run_bios(bios_img, no_graphic),
+        "uefi" => run_uefi(uefi_img, no_graphic),
+        "gui" => run_bios(bios_img, false),
         _ => {
-            eprintln!("Usage: cargo run -- [bios|uefi]");
+            eprintln!("Usage: cargo run -- [bios|uefi|gui] [--display]");
             process::exit(1);
         }
     }
 }
 
-fn run_bios(img: &str) {
+fn qemu_base_args(img: &str, no_graphic: bool) -> Command {
     let mut cmd = Command::new("qemu-system-x86_64");
-    cmd.arg("-nographic");
+    if no_graphic {
+        cmd.arg("-nographic");
+    }
     cmd.arg("-drive")
         .arg(format!("format=raw,file={img}"))
         .arg("-no-reboot")
         .arg("-device")
         .arg("isa-debug-exit,iobase=0xf4,iosize=0x04");
-    let status = cmd.status().unwrap();
+    cmd
+}
+
+fn run_bios(img: &str, no_graphic: bool) {
+    let status = qemu_base_args(img, no_graphic).status().unwrap();
     process::exit(status.code().unwrap_or(1));
 }
 
-fn run_uefi(img: &str) {
+fn run_uefi(img: &str, no_graphic: bool) {
     #[cfg(feature = "uefi")]
     {
         use ovmf_prebuilt::{Arch, FileType, Prebuilt, Source};
 
-        let prebuilt = Prebuilt::fetch(Source::LATEST, ".").expect("failed to fetch OVMF");
+        let prebuilt =
+            Prebuilt::fetch(Source::LATEST, "/tmp/yonti-os-ovmf").expect("failed to fetch OVMF");
         let ovmf = prebuilt.get_file(Arch::X64, FileType::Code);
 
-        let mut cmd = Command::new("qemu-system-x86_64");
-        cmd.arg("-nographic");
+        let mut cmd = qemu_base_args(img, no_graphic);
         cmd.arg("-bios").arg(ovmf);
-        cmd.arg("-drive")
-            .arg(format!("format=raw,file={img}"))
-            .arg("-no-reboot")
-            .arg("-device")
-            .arg("isa-debug-exit,iobase=0xf4,iosize=0x04");
         let status = cmd.status().unwrap();
         process::exit(status.code().unwrap_or(1));
     }
 
     #[cfg(not(feature = "uefi"))]
     {
-        let _ = img;
+        let _ = (img, no_graphic);
         eprintln!("error: UEFI support not compiled (build with --features uefi)");
         process::exit(1);
     }


### PR DESCRIPTION
Adds a `gui` subcommand and `--display` flag to the runner for launching QEMU with a display window (instead of headless serial-only). Also fixes OVMF prebuilt download path to `/tmp/yonti-os-ovmf` to prevent overwriting the `runner/` source directory.

```
cd runner && cargo run --bin runner -- gui
cd runner && cargo run --bin runner -- bios --display
```